### PR TITLE
fix: make sure picker exists before repositioning it

### DIFF
--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -4,27 +4,29 @@ import reset from '@scripts/reset';
 import { IVisibility, CSSClasses } from '@/package/types';
 
 const setPositionCalendar = (input: HTMLInputElement, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
-	const getPosition = {
-		top: -calendar.offsetHeight,
-		bottom: input.offsetHeight,
-		left: 0,
-		center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
-		right: input.offsetWidth - calendar.offsetWidth,
-	};
+	if (input) {
+		const getPosition = {
+			top: -calendar.offsetHeight,
+			bottom: input.offsetHeight,
+			left: 0,
+			center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
+			right: input.offsetWidth - calendar.offsetWidth,
+		};
 
-	const YPosition = !Array.isArray(position) ? 'bottom' : position[0];
-	const XPosition = !Array.isArray(position) ? position : position[1];
+		const YPosition = !Array.isArray(position) ? 'bottom' : position[0];
+		const XPosition = !Array.isArray(position) ? position : position[1];
 
-	calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
+		calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
 
-	const inputRect = input.getBoundingClientRect();
-	const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-	const scrollTop = window.scrollY || document.documentElement.scrollTop;
+		const inputRect = input.getBoundingClientRect();
+		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+		const scrollTop = window.scrollY || document.documentElement.scrollTop;
 
-	const top = inputRect.top + scrollTop + getPosition[YPosition];
-	const left = inputRect.left + scrollLeft + getPosition[XPosition];
+		const top = inputRect.top + scrollTop + getPosition[YPosition];
+		const left = inputRect.left + scrollLeft + getPosition[XPosition];
 
-	Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
+		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
+	}
 };
 
 const handleInput = (self: VanillaCalendar) => {

--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -3,30 +3,30 @@ import handleClick from '@scripts/handles/handleClick';
 import reset from '@scripts/reset';
 import { IVisibility, CSSClasses } from '@/package/types';
 
-const setPositionCalendar = (input: HTMLInputElement, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
-	if (input) {
-		const getPosition = {
-			top: -calendar.offsetHeight,
-			bottom: input.offsetHeight,
-			left: 0,
-			center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
-			right: input.offsetWidth - calendar.offsetWidth,
-		};
+const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
+	if (!input) return;
 
-		const YPosition = !Array.isArray(position) ? 'bottom' : position[0];
-		const XPosition = !Array.isArray(position) ? position : position[1];
+	const getPosition = {
+		top: -calendar.offsetHeight,
+		bottom: input.offsetHeight,
+		left: 0,
+		center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
+		right: input.offsetWidth - calendar.offsetWidth,
+	};
 
-		calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
+	const YPosition = !Array.isArray(position) ? 'bottom' : position[0];
+	const XPosition = !Array.isArray(position) ? position : position[1];
 
-		const inputRect = input.getBoundingClientRect();
-		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-		const scrollTop = window.scrollY || document.documentElement.scrollTop;
+	calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
 
-		const top = inputRect.top + scrollTop + getPosition[YPosition];
-		const left = inputRect.left + scrollLeft + getPosition[XPosition];
+	const inputRect = input.getBoundingClientRect();
+	const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+	const scrollTop = window.scrollY || document.documentElement.scrollTop;
 
-		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
-	}
+	const top = inputRect.top + scrollTop + getPosition[YPosition];
+	const left = inputRect.left + scrollLeft + getPosition[XPosition];
+
+	Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
 };
 
 const handleInput = (self: VanillaCalendar) => {
@@ -42,7 +42,7 @@ const handleInput = (self: VanillaCalendar) => {
 		firstInit = false;
 
 		setTimeout(() => {
-			setPositionCalendar(self.HTMLInputElement as HTMLInputElement, calendar, self.settings.visibility.positionToInput, self.CSSClasses);
+			setPositionCalendar(self.HTMLInputElement, calendar, self.settings.visibility.positionToInput, self.CSSClasses);
 			self.show();
 		}, 0);
 		reset(self, {
@@ -52,7 +52,7 @@ const handleInput = (self: VanillaCalendar) => {
 		return handleClick(self);
 	};
 
-	const handleResize = () => setPositionCalendar(self.HTMLInputElement as HTMLInputElement, self.HTMLElement, self.settings.visibility.positionToInput, self.CSSClasses);
+	const handleResize = () => setPositionCalendar(self.HTMLInputElement, self.HTMLElement, self.settings.visibility.positionToInput, self.CSSClasses);
 
 	const documentClickEvent = (e: MouseEvent) => {
 		if (!self || e.target === self.HTMLInputElement || self.HTMLElement?.contains(e.target as Node)) return;
@@ -65,7 +65,7 @@ const handleInput = (self: VanillaCalendar) => {
 		if (firstInit) {
 			cleanup.push(createCalendarToInput());
 		} else {
-			setPositionCalendar(self.HTMLInputElement as HTMLInputElement, self.HTMLElement, self.settings.visibility.positionToInput, self.CSSClasses);
+			setPositionCalendar(self.HTMLInputElement, self.HTMLElement, self.settings.visibility.positionToInput, self.CSSClasses);
 			self.show();
 		}
 		window.addEventListener('resize', handleResize);


### PR DESCRIPTION
- the method `setPositionCalendar` is sometime called within a `setTimeout` and in some cases the picker might have been destroyed before the repositioning starts and when that happens it could throws an error that reading `input.offsetHeight` is invalid.

for example, in my use case I opened a Modal window that has a form and one of the input has vanilla-calendar attached to it. If I click on the input to open the calendar picker and then close the modal window without closing calendar, it throws the error because the modal container is where the calendar was associated and but ended up being removed before the calendar has time to call the `setPositionCalendar` (because it was delayed by the `setTimeout`)

![msedge_LjAsOoUVG6](https://github.com/uvarov-frontend/vanilla-calendar-pro/assets/643976/621d84cc-71bf-452e-a69f-9d1c6be27efe)
