### PR TITLE
chore: clear html with `textContent` to be more CSP safe

### DIFF
--- a/demo/pages/input/main.ts
+++ b/demo/pages/input/main.ts
@@ -34,7 +34,7 @@ const configDiv: IOptions = {
 			if (self.selectedDates[0]) {
 				self.HTMLInputElement.innerHTML = self.selectedDates[0];
 			} else {
-				self.HTMLInputElement.innerHTML = '';
+				self.HTMLInputElement.textContent = '';
 			}
 			self.hide();
 		},

--- a/examples/additional-features-date-picker-in-input-div.ts
+++ b/examples/additional-features-date-picker-in-input-div.ts
@@ -12,7 +12,7 @@ const options: IOptions = {
         // if you want to hide the calendar after picking a date
         self.hide();
       } else {
-        self.HTMLInputElement.innerHTML = '';
+        self.HTMLInputElement.textContent = '';
       }
     },
   },

--- a/package/src/scripts/methods/createDays.ts
+++ b/package/src/scripts/methods/createDays.ts
@@ -161,7 +161,7 @@ const createDays = (self: VanillaCalendar) => {
 		const firstDayWeek = self.settings.iso8601 ? (firstDay.getDay() !== 0 ? firstDay.getDay() : 7) - 1 : firstDay.getDay();
 
 		if (self.settings.selection.day) daysEl.classList.add(self.CSSClasses.daysSelecting);
-		daysEl.innerHTML = '';
+		daysEl.textContent = '';
 
 		prevMonth(self, daysEl, selectedYear, selectedMonth, firstDayWeek);
 		currentMonth(self, daysEl, daysSelectedMonth, selectedYear, selectedMonth);

--- a/package/src/scripts/methods/createWeek.ts
+++ b/package/src/scripts/methods/createWeek.ts
@@ -2,7 +2,7 @@ import VanillaCalendar from '@src/vanilla-calendar';
 
 const createWeekDays = (self: VanillaCalendar, weekEl: HTMLElement, weekday: string[]) => {
 	const templateWeekDayEl = document.createElement('b');
-	weekEl.innerHTML = '';
+	weekEl.textContent = '';
 
 	for (let i = 0; i < weekday.length; i++) {
 		const weekDayName = weekday[i];

--- a/package/src/scripts/methods/createWeekNumbers.ts
+++ b/package/src/scripts/methods/createWeekNumbers.ts
@@ -22,7 +22,7 @@ const createWeekNumber = (
 
 const createWeekNumbers = (self: VanillaCalendar, firstDayWeek: number, daysSelectedMonth: number, weekNumbersEl: HTMLElement, daysEl: HTMLElement) => {
 	if (!self.settings.visibility.weekNumbers) return;
-	weekNumbersEl.innerHTML = '';
+	weekNumbersEl.textContent = '';
 
 	const weekNumbersTitleEl = document.createElement('b');
 	weekNumbersTitleEl.className = self.CSSClasses.weekNumbersTitle;


### PR DESCRIPTION
- using `textContent` is fully CSP safe and has the same effect which is to clear the element content
- more PRs will follow (after this PR is merged) to become more CSP safe
- as per MDN [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) docs
> Warning: Setting `textContent` on a node removes all of the node's children and replaces them with a single text node with the given string value.