### PR TITLE
feat: add `jumpToSelectedDate` option

### DIFF
--- a/docs/en/reference/main/main-settings.mdx
+++ b/docs/en/reference/main/main-settings.mdx
@@ -74,6 +74,31 @@ The `jumpMonths` parameter controls the number of months to jump.
 
 - - -
 
+## jumpToSelectedDate
+
+`Type: Boolean`
+
+`Default: false`
+
+`Options: true | false`
+
+```js
+new VanillaCalendar('#calendar', {
+	jumpToSelectedDate: true,
+  settings: {
+		selected: {
+			dates: ['2018-05-02'],
+		}
+  },
+});
+```
+
+When the option is enabled and 1 or more selected date(s) are provided but without providing `selected.month` and `selected.year`, it will make the calendar jump to the first selected date. If set to `'false'`, the calendar will always open to the current month and year.
+<Info>
+  This option has no effect when `selected.month` and `selected.year` are provided.
+</Info>
+---
+
 ## date.min
 
 `Type: String`

--- a/docs/en/reference/main/main-settings.mdx
+++ b/docs/en/reference/main/main-settings.mdx
@@ -93,11 +93,12 @@ new VanillaCalendar('#calendar', {
 });
 ```
 
-When the option is enabled and 1 or more selected date(s) are provided but without providing `selected.month` and `selected.year`, it will make the calendar jump to the first selected date. If set to `'false'`, the calendar will always open to the current month and year.
+When the option is enabled and 1 or more selected date(s) are provided but without providing `selected.month` and `selected.year`, it will make the calendar jump to the first selected date. If set to `false`, the calendar will always open to the current month and year.
 <Info>
   This option has no effect when `selected.month` and `selected.year` are provided.
 </Info>
----
+
+- - -
 
 ## date.min
 

--- a/docs/ru/reference/main/main-settings.mdx
+++ b/docs/ru/reference/main/main-settings.mdx
@@ -74,6 +74,32 @@ new VanillaCalendar('#calendar', {
 
 - - -
 
+## jumpToSelectedDate
+
+`Type: Boolean`
+
+`Default: false`
+
+`Options: true | false`
+
+```js
+new VanillaCalendar('#calendar', {
+	jumpToSelectedDate: true,
+  settings: {
+		selected: {
+			dates: ['2018-05-02'],
+		}
+  },
+});
+```
+
+Если эта опция включена и указаны одна или несколько выбранных дат, но без указания `selected.month` и `selected.year`, календарь перейдет к первой выбранной дате. Если установлено значение `false`, календарь всегда будет открываться для текущего месяца и года.
+<Info>
+  Эта опция не имеет эффекта, если указаны `selected.month` и `selected.year`.
+</Info>
+
+- - -
+
 ## date.min
 
 `Type: String`

--- a/package/src/scripts/default.ts
+++ b/package/src/scripts/default.ts
@@ -11,6 +11,7 @@ export default class DefaultOptionsCalendar {
 	type: T.TypesCalendar = 'default';
 	months = 2;
 	jumpMonths = 1;
+	jumpToSelectedDate = false;
 	date: T.IDates = {
 		min: '1970-01-01',
 		max: '2470-12-31',

--- a/package/src/scripts/helpers/setVariables.ts
+++ b/package/src/scripts/helpers/setVariables.ts
@@ -6,6 +6,11 @@ import getDate from '@scripts/helpers/getDate';
 import messages from './getMessages';
 
 const initSelectedMonthYear = (self: VanillaCalendar) => {
+	if (self.jumpToSelectedDate && self.settings.selected.dates?.length && (self.settings.selected.month === undefined && self.settings.selected.year === undefined)) {
+		const selectedDate = getDate(parseDates(self.settings.selected.dates)[0]);
+		self.settings.selected.month = selectedDate.getMonth();
+		self.settings.selected.year = selectedDate.getFullYear();
+	}
 	const isValidMonth = self.settings.selected.month !== undefined && Number(self.settings.selected.month) >= 0 && Number(self.settings.selected.month) < 12;
 	const isValidYear = self.settings.selected.year !== undefined && Number(self.settings.selected.year) >= 0 && Number(self.settings.selected.year) <= 9999;
 

--- a/package/types.ts
+++ b/package/types.ts
@@ -118,6 +118,7 @@ export interface IOptions {
 	type?: TypesCalendar;
 	months?: number;
 	jumpMonths?: number;
+	jumpToSelectedDate?: boolean;
 	date?: Partial<IDates>;
 	settings?: Partial<{
 		lang: string;


### PR DESCRIPTION
- default to `false` and when enabled, it will only be effective on the first selected date and also only work when `selected.month` and `selected.year` are both undefined
- fixes issue #250 (number 2 of discussion #244)
- it could be renamed to `gotoSelection` if you prefer