### PR TITLE
feat: add `'today'` as a shortcut to range min/max date

### DIFF
--- a/docs/en/reference/additionally/settings.mdx
+++ b/docs/en/reference/additionally/settings.mdx
@@ -48,7 +48,7 @@ This parameter sets the start of the week in accordance with the international s
 
 `Default: '1970-01-01'`
 
-`Options: 'YYYY-MM-DD'`
+`Options: 'YYYY-MM-DD' | 'today'`
 
 ```js
 new VanillaCalendar('#calendar', {
@@ -66,6 +66,10 @@ This parameter sets the minimum date that the user can choose. Dates earlier tha
   It's important to note that `settings.range.min` and `settings.range.max` disable dates outside the range, while `date.min` and `date.max` do not even create them.
 </Info>
 
+<Info>
+  You can provide `'today'` as a shortcut to `settings.range.min` and/or `settings.range.max`.
+</Info>
+
 ---
 
 ## settings.range.max
@@ -74,7 +78,7 @@ This parameter sets the minimum date that the user can choose. Dates earlier tha
 
 `Default: '2470-12-31'`
 
-`Options: 'YYYY-MM-DD'`
+`Options: 'YYYY-MM-DD' | 'today'`
 
 ```js
 new VanillaCalendar('#calendar', {
@@ -90,6 +94,10 @@ This parameter sets the maximum date that the user can choose. Dates later than 
 
 <Info>
   It's important to note that `settings.range.min` and `settings.range.max` disable dates outside the range, while `date.min` and `date.max` do not even create them.
+</Info>
+
+<Info>
+  You can provide `'today'` as a shortcut to `settings.range.min` and/or `settings.range.max`.
 </Info>
 
 ---

--- a/docs/ru/reference/additionally/settings.mdx
+++ b/docs/ru/reference/additionally/settings.mdx
@@ -49,7 +49,7 @@ new VanillaCalendar('#calendar', {
 
 `Default: '1970-01-01'`
 
-`Options: 'YYYY-MM-DD'`
+`Options: 'YYYY-MM-DD' | 'today'`
 
 ```js
 new VanillaCalendar('#calendar', {
@@ -67,6 +67,10 @@ new VanillaCalendar('#calendar', {
   Важно отметить, что `settings.range.min` и `settings.range.max` отключают даты, выходящие за пределы диапазона, в то время как `date.min` и `date.max` вообще их не создают.
 </Info>
 
+<Info>
+  Вы можете указать `'today'` как ярлык для `settings.range.min` и/или `settings.range.max`.
+</Info>
+
 ---
 
 ## settings.range.max
@@ -75,7 +79,7 @@ new VanillaCalendar('#calendar', {
 
 `Default: '2470-12-31'`
 
-`Options: 'YYYY-MM-DD'`
+`Options: 'YYYY-MM-DD' | 'today'`
 
 ```js
 new VanillaCalendar('#calendar', {
@@ -91,6 +95,10 @@ new VanillaCalendar('#calendar', {
 
 <Info>
   Важно отметить, что `settings.range.min` и `settings.range.max` отключают даты, выходящие за пределы диапазона, в то время как `date.min` и `date.max` вообще их не создают.
+</Info>
+
+<Info>
+  Вы можете указать `'today'` как ярлык для `settings.range.min` и/или `settings.range.max`.
 </Info>
 
 ---

--- a/package/src/scripts/helpers/getLocalDate.ts
+++ b/package/src/scripts/helpers/getLocalDate.ts
@@ -1,0 +1,8 @@
+import { FormatDateString } from '@package/types';
+
+const getLocalDate = () => {
+	const now = new Date();
+	return new Date(now.getTime() - (now.getTimezoneOffset() * 60000)).toISOString().substring(0, 10) as FormatDateString;
+};
+
+export default getLocalDate;

--- a/package/src/scripts/helpers/setVariables.ts
+++ b/package/src/scripts/helpers/setVariables.ts
@@ -3,6 +3,7 @@ import parseDates from '@scripts/helpers/parseDates';
 import getDateString from '@scripts/helpers/getDateString';
 import transformTime12 from '@scripts/helpers/transformTime12';
 import getDate from '@scripts/helpers/getDate';
+import { FormatDateString } from '@/package/types';
 import messages from './getMessages';
 
 const initSelectedMonthYear = (self: VanillaCalendar) => {
@@ -16,6 +17,12 @@ const initSelectedMonthYear = (self: VanillaCalendar) => {
 
 const initRange = (self: VanillaCalendar) => {
 	// set self.rangeMin and self.rangeMax
+	if (self.settings.range.min === 'today') {
+		self.settings.range.min = new Date().toISOString().substring(0, 10) as FormatDateString;
+	}
+	if (self.settings.range.max === 'today') {
+		self.settings.range.max = new Date().toISOString().substring(0, 10) as FormatDateString;
+	}
 	self.settings.range.min = getDate(self.date.min) >= getDate(self.settings.range.min) ? self.date.min : self.settings.range.min;
 	self.settings.range.max = getDate(self.date.max) <= getDate(self.settings.range.max) ? self.date.max : self.settings.range.max;
 

--- a/package/src/scripts/helpers/setVariables.ts
+++ b/package/src/scripts/helpers/setVariables.ts
@@ -1,9 +1,9 @@
 import VanillaCalendar from '@src/vanilla-calendar';
 import parseDates from '@scripts/helpers/parseDates';
 import getDateString from '@scripts/helpers/getDateString';
+import getLocalDate from '@scripts/helpers/getLocalDate';
 import transformTime12 from '@scripts/helpers/transformTime12';
 import getDate from '@scripts/helpers/getDate';
-import { FormatDateString } from '@/package/types';
 import messages from './getMessages';
 
 const initSelectedMonthYear = (self: VanillaCalendar) => {
@@ -18,10 +18,10 @@ const initSelectedMonthYear = (self: VanillaCalendar) => {
 const initRange = (self: VanillaCalendar) => {
 	// set self.rangeMin and self.rangeMax
 	if (self.settings.range.min === 'today') {
-		self.settings.range.min = new Date().toISOString().substring(0, 10) as FormatDateString;
+		self.settings.range.min = getLocalDate();
 	}
 	if (self.settings.range.max === 'today') {
-		self.settings.range.max = new Date().toISOString().substring(0, 10) as FormatDateString;
+		self.settings.range.max = getLocalDate();
 	}
 	self.settings.range.min = getDate(self.date.min) >= getDate(self.settings.range.min) ? self.date.min : self.settings.range.min;
 	self.settings.range.max = getDate(self.date.max) <= getDate(self.settings.range.max) ? self.date.max : self.settings.range.max;

--- a/package/types.ts
+++ b/package/types.ts
@@ -16,8 +16,8 @@ export interface IDates {
 }
 
 export interface IRange {
-	min: FormatDateString;
-	max: FormatDateString;
+	min: FormatDateString | 'today';
+	max: FormatDateString | 'today';
 	disablePast: boolean;
 	disableGaps: boolean;
 	disableAllDays: boolean;


### PR DESCRIPTION
- fixes number 4 of Discussion #244 by providing a `'today'` shortcut
- for example: `range: { min: 'today' }` or `selected: { dates: ['2001-02-04', 'today'] }`