### PR TITLE
feat: allow providing `Date` to min/max and selected dates

### DIFF
--- a/docs/en/reference/additionally/settings.mdx
+++ b/docs/en/reference/additionally/settings.mdx
@@ -17,6 +17,7 @@ new VanillaCalendar('#calendar', {
   },
 });
 ```
+
 This parameter sets the language localization of the calendar.
 You can specify a language label according to <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry" target="_blank" rel="nofollow noreferrer">BCP 47</a> or use `'define'` to customize your own month and weekday names, see <a href="/docs/reference/additionally/localization">`locale`</a> for more details.
 
@@ -44,19 +45,21 @@ This parameter sets the start of the week in accordance with the international s
 
 ## settings.range.min
 
-`Type: String | Date`
+`Type: String | Number | Date`
 
 `Default: '1970-01-01'`
 
-`Options: 'YYYY-MM-DD' | Date`
+`Options: 'YYYY-MM-DD' | Number | Date`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
       min: '2022-07-01',
-			// or
-			min: new Date('2018-01-01'),
+      // or
+      min: 1722152977141, // in milliseconds from 1970-01-01
+      // or
+      min: new Date('2018-01-01'),
     }
   },
 });
@@ -72,19 +75,21 @@ This parameter sets the minimum date that the user can choose. Dates earlier tha
 
 ## settings.range.max
 
-`Type: String | Date`
+`Type: String | Number | Date`
 
 `Default: '2470-12-31'`
 
-`Options: 'YYYY-MM-DD' | Date`
+`Options: 'YYYY-MM-DD' | Number | Date`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
       max: '2024-07-01',
-			// or
-			max: new Date('2018-01-01'),
+      // or
+      max: 1722152977141, // in milliseconds from 1970-01-01
+      // or
+      max: new Date('2018-01-01'),
     }
   },
 });
@@ -162,7 +167,6 @@ new VanillaCalendar('#calendar', {
 
 This parameter disables all days and can be useful when using <a href="/docs/reference/additionally/settings#range-enabled">`settings.range.enabled`</a>.
 
-
 ---
 
 ## settings.range.disableWeekday
@@ -189,17 +193,17 @@ This parameter allows you to disable specified weekdays. Specify an array with n
 
 ## settings.range.disabled
 
-`Type: String[] | Date[]`
+`Type: String[] | Number[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | [Date] | null`
+`Options: ['YYYY-MM-DD'] | [Number] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
-      disabled: ['2022-08-10:2022-08-15', '2022-08-20', new Date()],
+      disabled: ['2022-08-10:2022-08-15', '2022-08-20', 1722152977141, new Date()],
     }
   },
 });
@@ -215,17 +219,17 @@ This parameter allows you to disable specific dates regardless of the specified 
 
 ## settings.range.enabled
 
-`Type: String[]`
+`Type: String[] | Number[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | [Date] | null`
+`Options: ['YYYY-MM-DD'] | [Number] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
-      enabled: ['2022-08-11:2022-08-16', '2022-08-20', new Date()],
+      enabled: ['2022-08-11:2022-08-16', '2022-08-20', 1722152977141, new Date()],
     }
   },
 });
@@ -417,17 +421,17 @@ This option allows you to enable/disable cancellation of the selected date by pr
 
 ## settings.selected.dates
 
-`Type: String[] | Date[]`
+`Type: String[] | Number[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | [Date] | null`
+`Options: ['YYYY-MM-DD'] | [Number] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     selected: {
-      dates: ['2022-08-10:2022-08-15', '2022-08-20', new Date()],
+      dates: ['2022-08-10:2022-08-15', '2022-08-20', 1722152977141, new Date()],
     },
   },
 });
@@ -487,17 +491,17 @@ This parameter determines the year that will be displayed when the calendar is i
 
 ## settings.selected.holidays
 
-`Type: String[] | Date[]`
+`Type: String[] | Number[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | [Date] | null`
+`Options: ['YYYY-MM-DD'] | [Number] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     selected: {
-      holidays: ['2022-08-10:2022-08-15', '2022-08-20', new Date()],
+      holidays: ['2022-08-10:2022-08-15', '2022-08-20', 1722152977141, new Date()],
     },
   },
 });

--- a/docs/en/reference/additionally/settings.mdx
+++ b/docs/en/reference/additionally/settings.mdx
@@ -44,17 +44,19 @@ This parameter sets the start of the week in accordance with the international s
 
 ## settings.range.min
 
-`Type: String`
+`Type: String | Date`
 
 `Default: '1970-01-01'`
 
-`Options: 'YYYY-MM-DD'`
+`Options: 'YYYY-MM-DD' | Date`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
       min: '2022-07-01',
+			// or
+			min: new Date('2018-01-01'),
     }
   },
 });
@@ -70,17 +72,19 @@ This parameter sets the minimum date that the user can choose. Dates earlier tha
 
 ## settings.range.max
 
-`Type: String`
+`Type: String | Date`
 
 `Default: '2470-12-31'`
 
-`Options: 'YYYY-MM-DD'`
+`Options: 'YYYY-MM-DD' | Date`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
       max: '2024-07-01',
+			// or
+			max: new Date('2018-01-01'),
     }
   },
 });
@@ -185,17 +189,17 @@ This parameter allows you to disable specified weekdays. Specify an array with n
 
 ## settings.range.disabled
 
-`Type: String[]`
+`Type: String[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | null`
+`Options: ['YYYY-MM-DD'] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
-      disabled: ['2022-08-10:2022-08-15', '2022-08-20'],
+      disabled: ['2022-08-10:2022-08-15', '2022-08-20', new Date()],
     }
   },
 });
@@ -215,13 +219,13 @@ This parameter allows you to disable specific dates regardless of the specified 
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | null`
+`Options: ['YYYY-MM-DD'] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
-      enabled: ['2022-08-11:2022-08-16', '2022-08-20'],
+      enabled: ['2022-08-11:2022-08-16', '2022-08-20', new Date()],
     }
   },
 });
@@ -413,17 +417,17 @@ This option allows you to enable/disable cancellation of the selected date by pr
 
 ## settings.selected.dates
 
-`Type: String[]`
+`Type: String[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | null`
+`Options: ['YYYY-MM-DD'] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     selected: {
-      dates: ['2022-08-10:2022-08-15', '2022-08-20'],
+      dates: ['2022-08-10:2022-08-15', '2022-08-20', new Date()],
     },
   },
 });
@@ -483,17 +487,17 @@ This parameter determines the year that will be displayed when the calendar is i
 
 ## settings.selected.holidays
 
-`Type: String[]`
+`Type: String[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | null`
+`Options: ['YYYY-MM-DD'] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     selected: {
-      holidays: ['2022-08-10:2022-08-15', '2022-08-20'],
+      holidays: ['2022-08-10:2022-08-15', '2022-08-20', new Date()],
     },
   },
 });

--- a/docs/en/reference/main/main-settings.mdx
+++ b/docs/en/reference/main/main-settings.mdx
@@ -76,7 +76,7 @@ The `jumpMonths` parameter controls the number of months to jump.
 
 ## date.min
 
-`Type: String | Date`
+`Type: String | Number | Date`
 
 `Default: '1970-01-01'`
 
@@ -86,8 +86,10 @@ The `jumpMonths` parameter controls the number of months to jump.
 new VanillaCalendar('#calendar', {
   date: {
     min: '1970-01-01',
-		// or
-		min: new Date('2018-01-01'),
+    // or
+    min: 1722152977141, // in milliseconds from 1970-01-01
+    // or
+    min: new Date('2018-01-01'),
   },
 });
 ```
@@ -98,7 +100,7 @@ The `date.min` parameter sets the minimum allowable date that the calendar will 
 
 ## date.max
 
-`Type: String | Date`
+`Type: String | Number | Date`
 
 `Default: '2470-12-31'`
 
@@ -108,8 +110,10 @@ The `date.min` parameter sets the minimum allowable date that the calendar will 
 new VanillaCalendar('#calendar', {
   date: {
     max: '2470-12-31',
-		// or
-		max: new Date('2018-01-01'),
+    // or
+    max: 1722152977141, // in milliseconds from 1970-01-01
+    // or
+    max: new Date('2018-01-01'),
   },
 });
 ```

--- a/docs/en/reference/main/main-settings.mdx
+++ b/docs/en/reference/main/main-settings.mdx
@@ -80,7 +80,7 @@ The `jumpMonths` parameter controls the number of months to jump.
 
 `Default: '1970-01-01'`
 
-`Options: 'YYYY-MM-DD'`
+`Options: 'YYYY-MM-DD' | Number | Date`
 
 ```js
 new VanillaCalendar('#calendar', {
@@ -104,7 +104,7 @@ The `date.min` parameter sets the minimum allowable date that the calendar will 
 
 `Default: '2470-12-31'`
 
-`Options: 'YYYY-MM-DD'`
+`Options: 'YYYY-MM-DD' | Number | Date`
 
 ```js
 new VanillaCalendar('#calendar', {

--- a/docs/en/reference/main/main-settings.mdx
+++ b/docs/en/reference/main/main-settings.mdx
@@ -76,7 +76,7 @@ The `jumpMonths` parameter controls the number of months to jump.
 
 ## date.min
 
-`Type: String`
+`Type: String | Date`
 
 `Default: '1970-01-01'`
 
@@ -86,6 +86,8 @@ The `jumpMonths` parameter controls the number of months to jump.
 new VanillaCalendar('#calendar', {
   date: {
     min: '1970-01-01',
+		// or
+		min: new Date('2018-01-01'),
   },
 });
 ```
@@ -96,7 +98,7 @@ The `date.min` parameter sets the minimum allowable date that the calendar will 
 
 ## date.max
 
-`Type: String`
+`Type: String | Date`
 
 `Default: '2470-12-31'`
 
@@ -106,6 +108,8 @@ The `date.min` parameter sets the minimum allowable date that the calendar will 
 new VanillaCalendar('#calendar', {
   date: {
     max: '2470-12-31',
+		// or
+		max: new Date('2018-01-01'),
   },
 });
 ```

--- a/docs/ru/reference/additionally/settings.mdx
+++ b/docs/ru/reference/additionally/settings.mdx
@@ -45,17 +45,21 @@ new VanillaCalendar('#calendar', {
 
 ## settings.range.min
 
-`Type: String`
+`Type: String | Number | Date`
 
 `Default: '1970-01-01'`
 
-`Options: 'YYYY-MM-DD'`
+`Options: 'YYYY-MM-DD' | Number | Date`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
       min: '2022-07-01',
+      // or
+      min: 1722152977141, // in milliseconds from 1970-01-01
+      // or
+      min: new Date('2018-01-01'),
     }
   },
 });
@@ -71,17 +75,21 @@ new VanillaCalendar('#calendar', {
 
 ## settings.range.max
 
-`Type: String`
+`Type: String | Number | Date`
 
 `Default: '2470-12-31'`
 
-`Options: 'YYYY-MM-DD'`
+`Options: 'YYYY-MM-DD' | Number | Date`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
       max: '2024-07-01',
+      // or
+      max: 1722152977141, // in milliseconds from 1970-01-01
+      // or
+      max: new Date('2018-01-01'),
     }
   },
 });
@@ -185,17 +193,17 @@ new VanillaCalendar('#calendar', {
 
 ## settings.range.disabled
 
-`Type: String[]`
+`Type: String[] | Number[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | null`
+`Options: ['YYYY-MM-DD'] | [Number] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
-      disabled: ['2022-08-10:2022-08-15', '2022-08-20'],
+      disabled: ['2022-08-10:2022-08-15', '2022-08-20', 1722152977141, new Date()],
     }
   },
 });
@@ -211,17 +219,17 @@ new VanillaCalendar('#calendar', {
 
 ## settings.range.enabled
 
-`Type: String[]`
+`Type: String[] | Number[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | null`
+`Options: ['YYYY-MM-DD'] | [Number] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     range: {
-      enabled: ['2022-08-11:2022-08-16', '2022-08-20'],
+      enabled: ['2022-08-11:2022-08-16', '2022-08-20', 1722152977141, new Date()],
     }
   },
 });
@@ -413,17 +421,17 @@ new VanillaCalendar('#calendar', {
 
 ## settings.selected.dates
 
-`Type: String[]`
+`Type: String[] | Number[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | null`
+`Options: ['YYYY-MM-DD'] | [Number] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     selected: {
-      dates: ['2022-08-10:2022-08-15', '2022-08-20'],
+      dates: ['2022-08-10:2022-08-15', '2022-08-20', 1722152977141, new Date()],
     },
   },
 });
@@ -483,17 +491,17 @@ new VanillaCalendar('#calendar', {
 
 ## settings.selected.holidays
 
-`Type: String[]`
+`Type: String[] | Number[] | Date[]`
 
 `Default: null`
 
-`Options: ['YYYY-MM-DD'] | null`
+`Options: ['YYYY-MM-DD'] | [Number] | [Date] | null`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     selected: {
-      holidays: ['2022-08-10:2022-08-15', '2022-08-20'],
+      holidays: ['2022-08-10:2022-08-15', '2022-08-20', 1722152977141, new Date()],
     },
   },
 });

--- a/docs/ru/reference/main/main-settings.mdx
+++ b/docs/ru/reference/main/main-settings.mdx
@@ -76,7 +76,7 @@ new VanillaCalendar('#calendar', {
 
 ## date.min
 
-`Type: String`
+`Type: String | Number | Date`
 
 `Default: '1970-01-01'`
 
@@ -86,6 +86,10 @@ new VanillaCalendar('#calendar', {
 new VanillaCalendar('#calendar', {
   date: {
     min: '1970-01-01',
+    // or
+    min: 1722152977141, // in milliseconds from 1970-01-01
+    // or
+    min: new Date('2018-01-01'),
   },
 });
 ```
@@ -96,7 +100,7 @@ new VanillaCalendar('#calendar', {
 
 ## date.max
 
-`Type: String`
+`Type: String | Number | Date`
 
 `Default: '2470-12-31'`
 
@@ -106,6 +110,10 @@ new VanillaCalendar('#calendar', {
 new VanillaCalendar('#calendar', {
   date: {
     max: '2470-12-31',
+    // or
+    max: 1722152977141, // in milliseconds from 1970-01-01
+    // or
+    max: new Date('2018-01-01'),
   },
 });
 ```

--- a/package/src/scripts/helpers/parseDates.ts
+++ b/package/src/scripts/helpers/parseDates.ts
@@ -2,8 +2,11 @@ import { FormatDateString } from '@package/types';
 import getDateString from '@scripts/helpers/getDateString';
 import getDate from '@scripts/helpers/getDate';
 
-const parseDates = (dates: string[]): FormatDateString[] => dates.reduce((accumulator: FormatDateString[], date) => {
-	if (date.match(/^(\d{4}-\d{2}-\d{2})$/g)) {
+const parseDates = (dates: Array<number | string | Date>): FormatDateString[] => dates.reduce((accumulator: FormatDateString[], date) => {
+	if (date instanceof Date || typeof date === 'number') {
+		const d = date instanceof Date ? date : new Date(date);
+		accumulator.push(d.toISOString().substring(0, 10) as FormatDateString);
+	} else if (date.match(/^(\d{4}-\d{2}-\d{2})$/g)) {
 		accumulator.push(date as FormatDateString);
 	} else {
 		date.replace(/(\d{4}-\d{2}-\d{2}).*?(\d{4}-\d{2}-\d{2})/g, (_, startDateStr, endDateStr) => {

--- a/package/types.ts
+++ b/package/types.ts
@@ -38,7 +38,7 @@ export interface ISelection {
 }
 
 export interface ISelected {
-	dates?: string[];
+	dates?: Array<Date | number | string>;
 	month?: number;
 	year?: number;
 	holidays?: string[];


### PR DESCRIPTION
- in theory it also allow epoch timestamp (`number`) just because timestamp can be provided to `Date`
- fixes number 3 of Discussion #244