### PR TITLE
fix: use `.appendChild` for cross platform compatibility

### DIFF
--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -38,7 +38,7 @@ const handleInput = (self: VanillaCalendar) => {
 		const calendar = document.createElement('div');
 		calendar.className = `${self.CSSClasses.calendar} ${self.CSSClasses.calendarToInput} ${self.CSSClasses.calendarHidden}`;
 		self.HTMLElement = calendar;
-		document.body.append(self.HTMLElement);
+		document.body.appendChild(self.HTMLElement);
 		firstInit = false;
 
 		setTimeout(() => {

--- a/package/src/scripts/methods/createDays.ts
+++ b/package/src/scripts/methods/createDays.ts
@@ -95,15 +95,15 @@ const createDay = (
 	if (self.settings.visibility.weekNumbers) addWeekNumber();
 
 	if (otherMonth) {
-		if (self.settings.visibility.daysOutside) dayEl.append(dayBtnEl);
+		if (self.settings.visibility.daysOutside) dayEl.appendChild(dayBtnEl);
 	} else {
-		dayEl.append(dayBtnEl);
+		dayEl.appendChild(dayBtnEl);
 	}
 
 	setDisabledDays(self, date, dayWeekID);
 	setDayModifier(self, year, dayEl, dayBtnEl, dayWeekID, date, otherMonth);
 
-	daysEl.append(dayEl);
+	daysEl.appendChild(dayEl);
 	if (self.actions.getDays) self.actions.getDays(day, date, dayEl, dayBtnEl, self);
 };
 

--- a/package/src/scripts/methods/createMonths.ts
+++ b/package/src/scripts/methods/createMonths.ts
@@ -44,10 +44,10 @@ const createMonths = (self: VanillaCalendar, target?: HTMLElement) => {
 	for (let i = 0; i < 12; i++) {
 		const monthTitle = self.locale.months[i];
 		const monthDisabled = (i < (self.dateMin as Date).getMonth() + relationshipID(self) && selectedYear <= (self.dateMin as Date).getFullYear())
-		|| (i > (self.dateMax as Date).getMonth() + relationshipID(self) && selectedYear >= (self.dateMax as Date).getFullYear())
-		|| (i !== selectedMonth && !activeMonthsID.includes(i));
+			|| (i > (self.dateMax as Date).getMonth() + relationshipID(self) && selectedYear >= (self.dateMax as Date).getFullYear())
+			|| (i !== selectedMonth && !activeMonthsID.includes(i));
 		const monthEl = createMonthEl(self, templateMonthEl, selectedMonth, monthTitle, monthDisabled, i);
-		monthsEl.append(monthEl);
+		monthsEl.appendChild(monthEl);
 		if (self.actions.getMonths) self.actions.getMonths(i, monthEl, self);
 	}
 };

--- a/package/src/scripts/methods/createWeek.ts
+++ b/package/src/scripts/methods/createWeek.ts
@@ -15,7 +15,7 @@ const createWeekDays = (self: VanillaCalendar, weekEl: HTMLElement, weekday: str
 				? (i === 0 || i === 6 ? ` ${self.CSSClasses.weekDayWeekend}` : '')
 				: ''}`;
 		weekDayEl.innerText = `${weekDayName}`;
-		weekEl.append(weekDayEl);
+		weekEl.appendChild(weekDayEl);
 	}
 };
 

--- a/package/src/scripts/methods/createWeekNumbers.ts
+++ b/package/src/scripts/methods/createWeekNumbers.ts
@@ -17,7 +17,7 @@ const createWeekNumber = (
 	const weekNumberEl = templateWeekNumberEl.cloneNode(true) as HTMLElement;
 	weekNumberEl.innerText = String(weekNumber.week);
 	weekNumberEl.dataset.calendarYearWeek = String(weekNumber.year);
-	weekNumbersContentEl.append(weekNumberEl);
+	weekNumbersContentEl.appendChild(weekNumberEl);
 };
 
 const createWeekNumbers = (self: VanillaCalendar, firstDayWeek: number, daysSelectedMonth: number, weekNumbersEl: HTMLElement, daysEl: HTMLElement) => {
@@ -27,11 +27,11 @@ const createWeekNumbers = (self: VanillaCalendar, firstDayWeek: number, daysSele
 	const weekNumbersTitleEl = document.createElement('b');
 	weekNumbersTitleEl.className = self.CSSClasses.weekNumbersTitle;
 	weekNumbersTitleEl.innerText = '#';
-	weekNumbersEl.append(weekNumbersTitleEl);
+	weekNumbersEl.appendChild(weekNumbersTitleEl);
 
 	const weekNumbersContentEl = document.createElement('div');
 	weekNumbersContentEl.className = self.CSSClasses.weekNumbersContent;
-	weekNumbersEl.append(weekNumbersContentEl);
+	weekNumbersEl.appendChild(weekNumbersContentEl);
 
 	const templateWeekNumberEl = document.createElement('button');
 	templateWeekNumberEl.type = 'button';

--- a/package/src/scripts/methods/createYears.ts
+++ b/package/src/scripts/methods/createYears.ts
@@ -34,7 +34,7 @@ const createYears = (self: VanillaCalendar, target?: HTMLElement) => {
 	for (let i = (self.viewYear as number) - 7; i < (self.viewYear as number) + 8; i++) {
 		const yearDisabled = i < (self.dateMin as Date).getFullYear() + relationshipID || i > (self.dateMax as Date).getFullYear();
 		const yearEl = createYearEl(self, templateYearEl, selectedYear, yearDisabled, i);
-		yearsEl.append(yearEl);
+		yearsEl.appendChild(yearEl);
 		if (self.actions.getYears) self.actions.getYears(i, yearEl, self);
 	}
 };


### PR DESCRIPTION
- the `.append()` function is not compatible in Salesforce but `.appendChild()` is working fine and does the exact same thing in this context