### PR TITLE
Add multiple classes support for "CSSClasses" parameter.

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -7,45 +7,45 @@ import VanillaCalendar from '@src/vanilla-calendar';
 import '@src/styles/vanilla-calendar.css';
 
 const config: IOptions = {
-	CSSClasses: {
-		days: 'vanilla-calendar-days days-1 days-2 days-3 days-4',
-		day: 'vanilla-calendar-day day-1 day-2 day-3 day-4',
-		dayBtn: 'vanilla-calendar-day__btn day-btn-1 day-btn-2 day-btn-3 day-btn-4',
-		arrow: 'arrow-1 arrow-2 arrow-3 arrow-4',
-		arrowPrev: 'arrow-prev-1 arrow-prev-2 arrow-prev-3 arrow-prev-4',
-		arrowNext: 'arrow-next-1 arrow-next-2 arrow-next-3 arrow-next-4',
-		week: 'vanilla-calendar-week week-1 week-2 week-3 week-4',
-		weekDay: 'vanilla-calendar-week__day week-day-1 week-day-2 week-day-3 week-day-4',
-		weekDayWeekend: 'vanilla-calendar-week__day_weekend week-day-weekend-1 week-day-weekend-2 week-day-weekend-3 week-day-weekend-4',
-	},
-	iconsSet: {
-		arrowPrev: `<svg 
-			xmlns="http://www.w3.org/2000/svg" 
-			width="24" 
-			height="24" 
-			viewBox="0 0 24 24" 
-			fill="none" 
-			stroke="currentColor" 
-			stroke-width="2" 
-			stroke-linecap="round" 
-			stroke-linejoin="round"
-		>
-			<path d="m15 18-6-6 6-6"/>
-		</svg>`,
-		arrowNext: `<svg 
-			xmlns="http://www.w3.org/2000/svg" 
-			width="24" 
-			height="24" 
-			viewBox="0 0 24 24" 
-			fill="none" 
-			stroke="currentColor" 
-			stroke-width="2" 
-			stroke-linecap="round" 
-			stroke-linejoin="round"
-		>
-			<path d="m9 18 6-6-6-6"/>
-		</svg>`,
-	},
+	// CSSClasses: {
+	// 	days: 'vanilla-calendar-days days-1 days-2 days-3 days-4',
+	// 	day: 'vanilla-calendar-day day-1 day-2 day-3 day-4',
+	// 	dayBtn: 'vanilla-calendar-day__btn day-btn-1 day-btn-2 day-btn-3 day-btn-4',
+	// 	arrow: 'arrow-1 arrow-2 arrow-3 arrow-4',
+	// 	arrowPrev: 'arrow-prev-1 arrow-prev-2 arrow-prev-3 arrow-prev-4',
+	// 	arrowNext: 'arrow-next-1 arrow-next-2 arrow-next-3 arrow-next-4',
+	// 	week: 'vanilla-calendar-week week-1 week-2 week-3 week-4',
+	// 	weekDay: 'vanilla-calendar-week__day week-day-1 week-day-2 week-day-3 week-day-4',
+	// 	weekDayWeekend: 'vanilla-calendar-week__day_weekend week-day-weekend-1 week-day-weekend-2 week-day-weekend-3 week-day-weekend-4',
+	// },
+	// iconsSet: {
+	// 	arrowPrev: `<svg 
+	// 		xmlns="http://www.w3.org/2000/svg" 
+	// 		width="24" 
+	// 		height="24" 
+	// 		viewBox="0 0 24 24" 
+	// 		fill="none" 
+	// 		stroke="currentColor" 
+	// 		stroke-width="2" 
+	// 		stroke-linecap="round" 
+	// 		stroke-linejoin="round"
+	// 	>
+	// 		<path d="m15 18-6-6 6-6"/>
+	// 	</svg>`,
+	// 	arrowNext: `<svg 
+	// 		xmlns="http://www.w3.org/2000/svg" 
+	// 		width="24" 
+	// 		height="24" 
+	// 		viewBox="0 0 24 24" 
+	// 		fill="none" 
+	// 		stroke="currentColor" 
+	// 		stroke-width="2" 
+	// 		stroke-linecap="round" 
+	// 		stroke-linejoin="round"
+	// 	>
+	// 		<path d="m9 18 6-6-6-6"/>
+	// 	</svg>`,
+	// },
 	settings: {
 		selected: {
 			month: 3,

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -8,6 +8,7 @@ import '@src/styles/vanilla-calendar.css';
 
 const config: IOptions = {
 	CSSClasses: {
+		days: 'vanilla-calendar-days days-1 days-2 days-3 days-4',
 		day: 'vanilla-calendar-day day-1 day-2 day-3 day-4',
 		dayBtn: 'vanilla-calendar-day__btn day-btn-1 day-btn-2 day-btn-3 day-btn-4',
 		arrow: 'vanilla-calendar-arrow arrow-1 arrow-2 arrow-3 arrow-4',

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -11,12 +11,40 @@ const config: IOptions = {
 		days: 'vanilla-calendar-days days-1 days-2 days-3 days-4',
 		day: 'vanilla-calendar-day day-1 day-2 day-3 day-4',
 		dayBtn: 'vanilla-calendar-day__btn day-btn-1 day-btn-2 day-btn-3 day-btn-4',
-		arrow: 'vanilla-calendar-arrow arrow-1 arrow-2 arrow-3 arrow-4',
-		arrowPrev: 'vanilla-calendar-arrow_prev arrow-prev-1 arrow-prev-2 arrow-prev-3 arrow-prev-4',
-		arrowNext: 'vanilla-calendar-arrow_next arrow-next-1 arrow-next-2 arrow-next-3 arrow-next-4',
+		arrow: 'arrow-1 arrow-2 arrow-3 arrow-4',
+		arrowPrev: 'arrow-prev-1 arrow-prev-2 arrow-prev-3 arrow-prev-4',
+		arrowNext: 'arrow-next-1 arrow-next-2 arrow-next-3 arrow-next-4',
 		week: 'vanilla-calendar-week week-1 week-2 week-3 week-4',
 		weekDay: 'vanilla-calendar-week__day week-day-1 week-day-2 week-day-3 week-day-4',
 		weekDayWeekend: 'vanilla-calendar-week__day_weekend week-day-weekend-1 week-day-weekend-2 week-day-weekend-3 week-day-weekend-4',
+	},
+	iconsSet: {
+		arrowPrev: `<svg 
+			xmlns="http://www.w3.org/2000/svg" 
+			width="24" 
+			height="24" 
+			viewBox="0 0 24 24" 
+			fill="none" 
+			stroke="currentColor" 
+			stroke-width="2" 
+			stroke-linecap="round" 
+			stroke-linejoin="round"
+		>
+			<path d="m15 18-6-6 6-6"/>
+		</svg>`,
+		arrowNext: `<svg 
+			xmlns="http://www.w3.org/2000/svg" 
+			width="24" 
+			height="24" 
+			viewBox="0 0 24 24" 
+			fill="none" 
+			stroke="currentColor" 
+			stroke-width="2" 
+			stroke-linecap="round" 
+			stroke-linejoin="round"
+		>
+			<path d="m9 18 6-6-6-6"/>
+		</svg>`,
 	},
 	settings: {
 		selected: {

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -7,6 +7,9 @@ import VanillaCalendar from '@src/vanilla-calendar';
 import '@src/styles/vanilla-calendar.css';
 
 const config: IOptions = {
+	CSSClasses: {
+		dayBtn: 'vanilla-calendar-day__btn class2 class3 class4',
+	},
 	settings: {
 		selected: {
 			month: 3,

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -8,8 +8,11 @@ import '@src/styles/vanilla-calendar.css';
 
 const config: IOptions = {
 	CSSClasses: {
-		day: 'vanilla-calendar-day class2 class3 class4',
-		dayBtn: 'vanilla-calendar-day__btn class2 class3 class4',
+		day: 'vanilla-calendar-day day-1 day-2 day-3 day-4',
+		dayBtn: 'vanilla-calendar-day__btn day-btn-1 day-btn-2 day-btn-3 day-btn-4',
+		arrow: 'vanilla-calendar-arrow arrow-1 arrow-2 arrow-3 arrow-4',
+		arrowPrev: 'vanilla-calendar-arrow_prev arrow-prev-1 arrow-prev-2 arrow-prev-3 arrow-prev-4',
+		arrowNext: 'vanilla-calendar-arrow_next arrow-next-1 arrow-next-2 arrow-next-3 arrow-next-4',
 	},
 	settings: {
 		selected: {

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -8,6 +8,7 @@ import '@src/styles/vanilla-calendar.css';
 
 const config: IOptions = {
 	CSSClasses: {
+		day: 'vanilla-calendar-day class2 class3 class4',
 		dayBtn: 'vanilla-calendar-day__btn class2 class3 class4',
 	},
 	settings: {

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -13,6 +13,9 @@ const config: IOptions = {
 		arrow: 'vanilla-calendar-arrow arrow-1 arrow-2 arrow-3 arrow-4',
 		arrowPrev: 'vanilla-calendar-arrow_prev arrow-prev-1 arrow-prev-2 arrow-prev-3 arrow-prev-4',
 		arrowNext: 'vanilla-calendar-arrow_next arrow-next-1 arrow-next-2 arrow-next-3 arrow-next-4',
+		week: 'vanilla-calendar-week week-1 week-2 week-3 week-4',
+		weekDay: 'vanilla-calendar-week__day week-day-1 week-day-2 week-day-3 week-day-4',
+		weekDayWeekend: 'vanilla-calendar-week__day_weekend week-day-weekend-1 week-day-weekend-2 week-day-weekend-3 week-day-weekend-4',
 	},
 	settings: {
 		selected: {

--- a/package/src/scripts/default.ts
+++ b/package/src/scripts/default.ts
@@ -107,4 +107,7 @@ export default class DefaultOptionsCalendar {
 	viewYear!: number;
 	dateMin!: Date;
 	dateMax!: Date;
+
+	// Some option to add an icon, e.g. to the arrow.
+	iconsSet?: T.IIconsSet;
 }

--- a/package/src/scripts/handles/handleClickArrow.ts
+++ b/package/src/scripts/handles/handleClickArrow.ts
@@ -4,7 +4,7 @@ import createYears from '@scripts/methods/createYears';
 
 const handleClickArrow = (self: VanillaCalendar, event: MouseEvent) => {
 	const element = event.target as HTMLElement;
-	const arrowEl: HTMLElement | null = element.closest(`.${self.CSSClasses.arrow}`);
+	const arrowEl: HTMLElement | null = element.closest('[data-calendar-arrow]');
 
 	if (!arrowEl) return;
 

--- a/package/src/scripts/handles/handleClickDay.ts
+++ b/package/src/scripts/handles/handleClickDay.ts
@@ -7,8 +7,8 @@ import handleDaySelection from '@scripts/handles/handleDaySelection';
 
 const handleClickDay = (self: VanillaCalendar, event: MouseEvent) => {
 	const element = event.target as HTMLElement;
-	const closest = (className: string): HTMLElement | null => element.closest(`.${className}`);
-	const dayBtnEl: HTMLElement | null = closest(self.CSSClasses.dayBtn);
+	const closest = (className: string, isClass = true): HTMLElement | null => element.closest(isClass ? `.${className}` : className);
+	const dayBtnEl: HTMLElement | null = closest('[data-element-day-btn]', false);
 
 	if (!self.settings.selection.day || !['single', 'multiple', 'multiple-ranged'].includes(self.settings.selection.day) || !dayBtnEl) return;
 

--- a/package/src/scripts/handles/handleClickDay.ts
+++ b/package/src/scripts/handles/handleClickDay.ts
@@ -7,8 +7,7 @@ import handleDaySelection from '@scripts/handles/handleDaySelection';
 
 const handleClickDay = (self: VanillaCalendar, event: MouseEvent) => {
 	const element = event.target as HTMLElement;
-	const closest = (className: string, isClass = true): HTMLElement | null => element.closest(isClass ? `.${className}` : className);
-	const dayBtnEl: HTMLElement | null = closest('[data-calendar-day-btn]', false);
+	const dayBtnEl: HTMLElement | null = element.closest('[data-calendar-day-btn]');
 
 	if (!self.settings.selection.day || !['single', 'multiple', 'multiple-ranged'].includes(self.settings.selection.day) || !dayBtnEl) return;
 
@@ -30,8 +29,8 @@ const handleClickDay = (self: VanillaCalendar, event: MouseEvent) => {
 		);
 	}
 
-	const dayBtnPrevEl = closest(self.CSSClasses.dayBtnPrev);
-	const dayBtnNextEl = closest(self.CSSClasses.dayBtnNext);
+	const dayBtnPrevEl = element.closest('[data-calendar-day-btn="prev"]');
+	const dayBtnNextEl = element.closest('[data-calendar-day-btn="next"]');
 
 	const actionMapping = {
 		prev: () => changeMonth(self, 'prev'),

--- a/package/src/scripts/handles/handleClickDay.ts
+++ b/package/src/scripts/handles/handleClickDay.ts
@@ -8,7 +8,7 @@ import handleDaySelection from '@scripts/handles/handleDaySelection';
 const handleClickDay = (self: VanillaCalendar, event: MouseEvent) => {
 	const element = event.target as HTMLElement;
 	const closest = (className: string, isClass = true): HTMLElement | null => element.closest(isClass ? `.${className}` : className);
-	const dayBtnEl: HTMLElement | null = closest('[data-element-day-btn]', false);
+	const dayBtnEl: HTMLElement | null = closest('[data-calendar-day-btn]', false);
 
 	if (!self.settings.selection.day || !['single', 'multiple', 'multiple-ranged'].includes(self.settings.selection.day) || !dayBtnEl) return;
 

--- a/package/src/scripts/handles/handleDayRangedSelection.ts
+++ b/package/src/scripts/handles/handleDayRangedSelection.ts
@@ -21,8 +21,12 @@ const removeHoverEffect = () => {
 
 	const dayEls: NodeListOf<HTMLDivElement> = current.self.HTMLElement.querySelectorAll(`.${current.self.CSSClasses.dayBtnHover}`);
 	dayEls.forEach((d) => {
-		d.classList.remove((current.self as VanillaCalendar).CSSClasses.dayBtnHover);
-		d.parentElement?.classList.remove(CSSClasses.dayHoverIntermediate, CSSClasses.dayHoverFirst, CSSClasses.dayHoverLast);
+		d.classList.remove(...(current.self as VanillaCalendar).CSSClasses.dayBtnHover.trim().split(' '));
+		d.parentElement?.classList.remove(
+			...CSSClasses.dayHoverIntermediate.trim().split(' '),
+			...CSSClasses.dayHoverFirst.trim().split(' '),
+			...CSSClasses.dayHoverLast.trim().split(' '),
+		);
 	});
 };
 
@@ -36,12 +40,12 @@ const addHoverEffect = (day: Date, firstBtnDayEls: NodeListOf<HTMLDivElement>, l
 
 	const dayEls: NodeListOf<HTMLDivElement> = current.self.HTMLElement?.querySelectorAll(`[data-calendar-day="${formattedDate}"]`);
 	dayEls?.forEach((d) => {
-		d.classList.add(CSSClasses.dayBtnHover);
-		d.parentElement?.classList.add(CSSClasses.dayHoverIntermediate);
+		d.classList.add(...CSSClasses.dayBtnHover.trim().split(' '));
+		d.parentElement?.classList.add(...CSSClasses.dayHoverIntermediate.trim().split(' '));
 	});
 
-	firstBtnDayEls?.forEach((d) => d.parentElement?.classList.add(CSSClasses.dayHoverFirst));
-	lastBtnDayEls?.forEach((d) => d.parentElement?.classList.add(CSSClasses.dayHoverLast));
+	firstBtnDayEls?.forEach((d) => d.parentElement?.classList.add(...CSSClasses.dayHoverFirst.trim().split(' ')));
+	lastBtnDayEls?.forEach((d) => d.parentElement?.classList.add(...CSSClasses.dayHoverLast.trim().split(' ')));
 };
 
 const handleHoverDaysEvent = (e: MouseEvent) => {

--- a/package/src/scripts/handles/handleDayRangedSelection.ts
+++ b/package/src/scripts/handles/handleDayRangedSelection.ts
@@ -47,7 +47,7 @@ const addHoverEffect = (day: Date, firstBtnDayEls: NodeListOf<HTMLDivElement>, l
 const handleHoverDaysEvent = (e: MouseEvent) => {
 	if (!e.target || !current.self?.selectedDates) return;
 
-	const days: HTMLDivElement | null = (e.target as HTMLElement).closest(`.${current.self.CSSClasses.days}`);
+	const days: HTMLDivElement | null = (e.target as HTMLElement).closest('[data-calendar-days]');
 
 	if (!days) {
 		removeHoverEffect();

--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -17,7 +17,7 @@ const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTML
 	const YPosition = !Array.isArray(position) ? 'bottom' : position[0];
 	const XPosition = !Array.isArray(position) ? position : position[1];
 
-	calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
+	calendar.classList.add(...(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop).trim().split(' '));
 
 	const inputRect = input.getBoundingClientRect();
 	const scrollLeft = window.scrollX || document.documentElement.scrollLeft;

--- a/package/src/scripts/helpers/createComponents.ts
+++ b/package/src/scripts/helpers/createComponents.ts
@@ -3,14 +3,18 @@ import VanillaCalendar from '@src/vanilla-calendar';
 export const ArrowPrev = (self: VanillaCalendar) => (`
 	<button type="button"
 		class="${self.CSSClasses.arrow} ${self.CSSClasses.arrowPrev}"
-		data-calendar-arrow="prev">
+		data-calendar-arrow="prev"
+	>
+		${self.iconsSet?.arrowPrev || ''}
 	</button>
 `);
 
 export const ArrowNext = (self: VanillaCalendar) => (`
 	<button type="button"
 		class="${self.CSSClasses.arrow} ${self.CSSClasses.arrowNext}"
-		data-calendar-arrow="next">
+		data-calendar-arrow="next"
+	>
+		${self.iconsSet?.arrowNext || ''}
 	</button>
 `);
 

--- a/package/src/scripts/helpers/createComponents.ts
+++ b/package/src/scripts/helpers/createComponents.ts
@@ -29,11 +29,11 @@ export const Year = (self: VanillaCalendar) => (`
 `);
 
 export const Week = (self: VanillaCalendar) => (`
-	<div class="${self.CSSClasses.week}"></div>
+	<div class="${self.CSSClasses.week}" data-calendar-week></div>
 `);
 
 export const Days = (self: VanillaCalendar) => (`
-	<div class="${self.CSSClasses.days}"></div>
+	<div class="${self.CSSClasses.days}" data-calendar-days></div>
 `);
 
 export const Months = (self: VanillaCalendar) => (`

--- a/package/src/scripts/hide.ts
+++ b/package/src/scripts/hide.ts
@@ -2,7 +2,7 @@ import VanillaCalendar from '@src/vanilla-calendar';
 
 const hide = (self: VanillaCalendar) => {
 	if (!self.currentType) return;
-	self.HTMLElement.classList.add(self.CSSClasses.calendarHidden);
+	self.HTMLElement.classList.add(...self.CSSClasses.calendarHidden.trim().split(' '));
 	if (self.actions.hideCalendar) self.actions.hideCalendar(self);
 };
 

--- a/package/src/scripts/methods/changeTime.ts
+++ b/package/src/scripts/methods/changeTime.ts
@@ -11,8 +11,8 @@ const getInputElement = (
 ) => timeEl.querySelector(`.${className}${name ? ` input[name="${name}"]` : ''}`) as HTMLInputElement;
 
 const addMouseEvents = (range: HTMLInputElement, input: HTMLInputElement, CSSClass: string) => {
-	range.addEventListener('mouseover', () => input.classList.add(CSSClass));
-	range.addEventListener('mouseout', () => input.classList.remove(CSSClass));
+	range.addEventListener('mouseover', () => input.classList.add(...CSSClass.trim().split(' ')));
+	range.addEventListener('mouseout', () => input.classList.remove(...CSSClass.trim().split(' ')));
 };
 
 const setTime = (self: VanillaCalendar, e: Event, value: string, type: TypeTime) => {

--- a/package/src/scripts/methods/createDOM.ts
+++ b/package/src/scripts/methods/createDOM.ts
@@ -18,23 +18,23 @@ const createDOM = (self: VanillaCalendar, target?: HTMLElement) => {
 		if (controls) HTMLElement.removeChild(controls);
 
 		const grid = HTMLElement.querySelector(`.${CSSClasses.grid}`) as HTMLElement;
-		grid.classList.add(CSSClasses.gridDisabled);
+		grid.classList.add(...CSSClasses.gridDisabled.trim().split(' '));
 
 		const columnElement = target.closest(`.${CSSClasses.column}`) as HTMLElement;
-		columnElement.classList.add(columnClass);
+		columnElement.classList.add(...columnClass.trim().split(' '));
 		columnElement.innerHTML = DOMParser(self, DOMTemplate);
 	};
 
 	const typeHandlers = {
 		default: () => {
-			HTMLElement.classList.add(CSSClasses.calendarDefault);
-			HTMLElement.classList.remove(CSSClasses.calendarMonth, CSSClasses.calendarYear);
+			HTMLElement.classList.add(...CSSClasses.calendarDefault.trim().split(' '));
+			HTMLElement.classList.remove(...CSSClasses.calendarMonth.trim().split(' '), ...CSSClasses.calendarYear.trim().split(' '));
 			HTMLElement.innerHTML = DOMParser(self, DOMTemplates.default);
 		},
 		multiple: () => {
 			if (!correctMonths) return;
-			HTMLElement.classList.add(CSSClasses.calendarMultiple);
-			HTMLElement.classList.remove(CSSClasses.calendarMonth, CSSClasses.calendarYear);
+			HTMLElement.classList.add(...CSSClasses.calendarMultiple.trim().split(' '));
+			HTMLElement.classList.remove(...CSSClasses.calendarMonth.trim().split(' '), ...CSSClasses.calendarYear.trim().split(' '));
 			HTMLElement.innerHTML = MultipleParser(self, DOMParser(self, DOMTemplates.multiple));
 		},
 		month: () => {
@@ -42,8 +42,8 @@ const createDOM = (self: VanillaCalendar, target?: HTMLElement) => {
 				updateGridAndControls(CSSClasses.columnMonth, DOMTemplates.month);
 				return;
 			}
-			HTMLElement.classList.add(CSSClasses.calendarMonth);
-			HTMLElement.classList.remove(CSSClasses.calendarDefault, CSSClasses.calendarYear);
+			HTMLElement.classList.add(...CSSClasses.calendarMonth.trim().split(' '));
+			HTMLElement.classList.remove(...CSSClasses.calendarDefault.trim().split(' '), ...CSSClasses.calendarYear.trim().split(' '));
 			HTMLElement.innerHTML = DOMParser(self, DOMTemplates.month);
 		},
 		year: () => {
@@ -51,13 +51,13 @@ const createDOM = (self: VanillaCalendar, target?: HTMLElement) => {
 				updateGridAndControls(CSSClasses.columnYear, DOMTemplates.year);
 				return;
 			}
-			HTMLElement.classList.add(CSSClasses.calendarYear);
-			HTMLElement.classList.remove(CSSClasses.calendarDefault, CSSClasses.calendarMonth);
+			HTMLElement.classList.add(...CSSClasses.calendarYear.trim().split(' '));
+			HTMLElement.classList.remove(...CSSClasses.calendarDefault.trim().split(' '), ...CSSClasses.calendarMonth.trim().split(' '));
 			HTMLElement.innerHTML = DOMParser(self, DOMTemplates.year);
 		},
 	};
 
-	HTMLElement.classList.add(CSSClasses.calendar);
+	HTMLElement.classList.add(...CSSClasses.calendar.trim().split(' '));
 	typeHandlers[currentType]();
 };
 

--- a/package/src/scripts/methods/createDays.ts
+++ b/package/src/scripts/methods/createDays.ts
@@ -79,10 +79,12 @@ const createDay = (
 ) => {
 	const dayEl = document.createElement('div');
 	dayEl.className = self.CSSClasses.day;
+	dayEl.setAttribute('data-element-day', '');
 
 	const dayBtnEl = document.createElement('button');
 	dayBtnEl.className = `${self.CSSClasses.dayBtn}${modifier ? ` ${modifier}` : ''}`;
 	dayBtnEl.type = 'button';
+	dayBtnEl.setAttribute('data-element-day-btn', '');
 	dayBtnEl.innerText = String(day);
 	dayBtnEl.dataset.calendarDay = date;
 

--- a/package/src/scripts/methods/createDays.ts
+++ b/package/src/scripts/methods/createDays.ts
@@ -147,8 +147,8 @@ const nextMonth = (self: VanillaCalendar, daysEl: HTMLElement, daysSelectedMonth
 };
 
 const createDays = (self: VanillaCalendar) => {
-	const daysEls: NodeListOf<HTMLElement> = self.HTMLElement.querySelectorAll(`.${self.CSSClasses.days}`);
-	const weekNumbersEls: NodeListOf<HTMLElement> = self.HTMLElement.querySelectorAll(`.${self.CSSClasses.weekNumbers}`);
+	const daysEls: NodeListOf<HTMLElement> = self.HTMLElement.querySelectorAll('[data-calendar-days]');
+	const weekNumbersEls: NodeListOf<HTMLElement> = self.HTMLElement.querySelectorAll('[data-calendar-week-numbers]');
 	const initDate = new Date(self.selectedYear as number, self.selectedMonth as number, 1);
 
 	daysEls.forEach((daysEl, index: number) => {

--- a/package/src/scripts/methods/createDays.ts
+++ b/package/src/scripts/methods/createDays.ts
@@ -79,12 +79,12 @@ const createDay = (
 ) => {
 	const dayEl = document.createElement('div');
 	dayEl.className = self.CSSClasses.day;
-	dayEl.setAttribute('data-element-day', '');
+	dayEl.setAttribute('data-calendar-day', '');
 
 	const dayBtnEl = document.createElement('button');
 	dayBtnEl.className = `${self.CSSClasses.dayBtn}${modifier ? ` ${modifier}` : ''}`;
 	dayBtnEl.type = 'button';
-	dayBtnEl.setAttribute('data-element-day-btn', '');
+	dayBtnEl.setAttribute('data-calendar-day-btn', '');
 	dayBtnEl.innerText = String(day);
 	dayBtnEl.dataset.calendarDay = date;
 

--- a/package/src/scripts/methods/createMonths.ts
+++ b/package/src/scripts/methods/createMonths.ts
@@ -31,7 +31,7 @@ const createMonths = (self: VanillaCalendar, target?: HTMLElement) => {
 	const monthsEl = self.HTMLElement?.querySelector(`.${self.CSSClasses.months}`);
 	if (!self.settings.selection.month || !monthsEl) return;
 
-	monthsEl.classList.add(self.CSSClasses.monthsSelecting);
+	monthsEl.classList.add(...self.CSSClasses.monthsSelecting.trim().split(' '));
 
 	const activeMonthsID = self.jumpMonths > 1 ? self.locale.months
 		.map((_, i) => selectedMonth - self.jumpMonths * i)

--- a/package/src/scripts/methods/createPopup.ts
+++ b/package/src/scripts/methods/createPopup.ts
@@ -4,7 +4,7 @@ import VanillaCalendar from '@src/vanilla-calendar';
 const handleDay = (date: string, dayInfo: IPopup, daysEl: HTMLElement, CSSClasses: string) => {
 	const dayBtnEl: HTMLElement | null = daysEl.querySelector(`[data-calendar-day="${date}"]`);
 	if (!dayBtnEl) return;
-	if (dayInfo?.modifier) dayBtnEl.classList.add(...dayInfo.modifier.trim().split(' '));
+	if (dayInfo?.modifier) dayBtnEl.classList.add(...dayInfo.modifier.trim().trim().split(' '));
 	if (dayInfo?.html) (dayBtnEl.parentElement as HTMLElement).innerHTML += `<div class="${CSSClasses}">${dayInfo.html}</div>`;
 };
 

--- a/package/src/scripts/methods/createWeek.ts
+++ b/package/src/scripts/methods/createWeek.ts
@@ -7,6 +7,10 @@ const createWeekDays = (self: VanillaCalendar, weekEl: HTMLElement, weekday: str
 	for (let i = 0; i < weekday.length; i++) {
 		const weekDayName = weekday[i];
 		const weekDayEl = templateWeekDayEl.cloneNode(true) as HTMLElement;
+		weekDayEl.setAttribute('data-calendar-week-day', '');
+		if (self.settings.visibility.weekend && self.settings.iso8601 && (i === 5 || i === 6)) {
+			weekDayEl.setAttribute('data-calendar-week-day-weekend', '');
+		}
 		weekDayEl.className = `${self.CSSClasses.weekDay}`;
 		weekDayEl.className = `${self.CSSClasses.weekDay}${self.settings.visibility.weekend && self.settings.iso8601
 			? (i === 5 || i === 6
@@ -23,7 +27,7 @@ const createWeek = (self: VanillaCalendar) => {
 	const weekday = [...self.locale.weekday];
 	if (!weekday[0]) return;
 	if (self.settings.iso8601) weekday.push((weekday.shift() as string));
-	const weekEls: NodeListOf<HTMLElement> = self.HTMLElement.querySelectorAll(`.${self.CSSClasses.week}`);
+	const weekEls: NodeListOf<HTMLElement> = self.HTMLElement.querySelectorAll('[data-calendar-week]');
 	weekEls.forEach((weekEl) => createWeekDays(self, weekEl, weekday));
 };
 

--- a/package/src/scripts/methods/createWeekNumbers.ts
+++ b/package/src/scripts/methods/createWeekNumbers.ts
@@ -9,7 +9,7 @@ const createWeekNumber = (
 	templateWeekNumberEl: HTMLButtonElement,
 	weekNumbersContentEl: HTMLDivElement,
 ) => {
-	const dayBtnEl: HTMLElement | null = dayEls[index].querySelector(`.${self.CSSClasses.dayBtn}`);
+	const dayBtnEl: HTMLElement | null = dayEls[index].querySelector('[data-element-day-btn]');
 	const weekNumber = getWeekNumber(dayBtnEl?.dataset.calendarDay as FormatDateString | undefined, self.settings.iso8601);
 
 	if (!weekNumber) return;

--- a/package/src/scripts/methods/createWeekNumbers.ts
+++ b/package/src/scripts/methods/createWeekNumbers.ts
@@ -37,7 +37,7 @@ const createWeekNumbers = (self: VanillaCalendar, firstDayWeek: number, daysSele
 	templateWeekNumberEl.type = 'button';
 	templateWeekNumberEl.className = self.CSSClasses.weekNumber;
 
-	const dayEls: NodeListOf<HTMLElement> = daysEl.querySelectorAll(`.${self.CSSClasses.day}`);
+	const dayEls: NodeListOf<HTMLElement> = daysEl.querySelectorAll('[data-element-day]');
 	const weeksCount = Math.ceil((firstDayWeek + daysSelectedMonth) / 7);
 
 	for (let i = 0; i < weeksCount; i++) {

--- a/package/src/scripts/methods/createWeekNumbers.ts
+++ b/package/src/scripts/methods/createWeekNumbers.ts
@@ -9,7 +9,7 @@ const createWeekNumber = (
 	templateWeekNumberEl: HTMLButtonElement,
 	weekNumbersContentEl: HTMLDivElement,
 ) => {
-	const dayBtnEl: HTMLElement | null = dayEls[index].querySelector('[data-element-day-btn]');
+	const dayBtnEl: HTMLElement | null = dayEls[index].querySelector('[data-calendar-day-btn]');
 	const weekNumber = getWeekNumber(dayBtnEl?.dataset.calendarDay as FormatDateString | undefined, self.settings.iso8601);
 
 	if (!weekNumber) return;
@@ -37,7 +37,7 @@ const createWeekNumbers = (self: VanillaCalendar, firstDayWeek: number, daysSele
 	templateWeekNumberEl.type = 'button';
 	templateWeekNumberEl.className = self.CSSClasses.weekNumber;
 
-	const dayEls: NodeListOf<HTMLElement> = daysEl.querySelectorAll('[data-element-day]');
+	const dayEls: NodeListOf<HTMLElement> = daysEl.querySelectorAll('[data-calendar-day]');
 	const weeksCount = Math.ceil((firstDayWeek + daysSelectedMonth) / 7);
 
 	for (let i = 0; i < weeksCount; i++) {

--- a/package/src/scripts/methods/createYears.ts
+++ b/package/src/scripts/methods/createYears.ts
@@ -24,7 +24,7 @@ const createYears = (self: VanillaCalendar, target?: HTMLElement) => {
 	const yearsEl = self.HTMLElement.querySelector(`.${self.CSSClasses.years}`);
 	if (!self.settings.selection.year || !yearsEl) return;
 
-	yearsEl.classList.add(self.CSSClasses.yearsSelecting);
+	yearsEl.classList.add(...self.CSSClasses.yearsSelecting.trim().split(' '));
 
 	const relationshipID = self.type !== 'multiple' ? 0 : self.selectedYear === selectedYear ? 0 : 1;
 

--- a/package/src/scripts/methods/visibilityArrows.ts
+++ b/package/src/scripts/methods/visibilityArrows.ts
@@ -17,8 +17,8 @@ const setVisibilityArrows = ({
 const visibilityArrows = (self: VanillaCalendar) => {
 	if (self.currentType === 'month') return;
 
-	const arrowPrev: HTMLElement | null = self.HTMLElement?.querySelector(`.${self.CSSClasses.arrowPrev}`);
-	const arrowNext: HTMLElement | null = self.HTMLElement?.querySelector(`.${self.CSSClasses.arrowNext}`);
+	const arrowPrev: HTMLElement | null = self.HTMLElement?.querySelector('[data-calendar-arrow="prev"]');
+	const arrowNext: HTMLElement | null = self.HTMLElement?.querySelector('[data-calendar-arrow="next"]');
 
 	if (!arrowPrev || !arrowNext) return;
 

--- a/package/src/scripts/show.ts
+++ b/package/src/scripts/show.ts
@@ -5,7 +5,7 @@ const show = (self: VanillaCalendar) => {
 		self.HTMLElement.click();
 		return;
 	}
-	self.HTMLElement.classList.remove(self.CSSClasses.calendarHidden);
+	self.HTMLElement.classList.remove(...self.CSSClasses.calendarHidden.trim().split(' '));
 	if (self.actions.showCalendar) self.actions.showCalendar(self);
 };
 

--- a/package/types.ts
+++ b/package/types.ts
@@ -132,6 +132,9 @@ export interface IOptions {
 	popups?: IPopups;
 	CSSClasses?: Partial<CSSClasses>;
 	DOMTemplates?: Partial<IDOMTemplates>;
+
+	// Some option to add an icon, e.g. to the arrow.
+	iconsSet?: IIconsSet;
 }
 
 export interface IVanillaCalendar {
@@ -181,4 +184,12 @@ export interface IVanillaCalendar {
 	readonly dateMin: Date;
 	readonly dateMax: Date;
 	readonly isInit: boolean;
+
+	// Some option to add an icon, e.g. to the arrow.
+	iconsSet?: IIconsSet;
+}
+
+export interface IIconsSet {
+	arrowPrev?: string;
+	arrowNext?: string;
 }


### PR DESCRIPTION
Closes #247 

Hi,
Thanks for the great plugin. I've added some improvements so that you can use the `CSSClasses` property with multiple classes. This is very useful for the headless ui approach, such as using a Tailwind CSS.

- Ability to add multiple classes to "dayBtn" using the "CSSClasses" parameters.
- Ability to add multiple classes to "day" using the "CSSClasses" parameters.
- Ability to add multiple classes to "arrow", "arrowPrev", "arrowNext" using the "CSSClasses" parameters.
- Ability to add multiple classes to "week", "weekDay", "weekDayWeekend" using the "CSSClasses" parameters.
- Ability to add custom icon to the "arrowPrev" and "arrowNext" via "iconsSet" parameter.

PS: Please uncomment the code inside the `demo/main.ts` file to test the improvements and the new added `iconsSet` parameter.
