### PR TITLE
feat: add new `edgesOnly` to return only start/end dates in selection range

### DIFF
--- a/docs/en/reference/additionally/settings.mdx
+++ b/docs/en/reference/additionally/settings.mdx
@@ -97,7 +97,7 @@ new VanillaCalendar('#calendar', {
       // or
       max: new Date('2018-01-01'),
       // or
-      ma: 'today',
+      max: 'today',
     }
   },
 });
@@ -156,6 +156,32 @@ new VanillaCalendar('#calendar', {
 ```
 
 This parameter disables the selection of days within a range with disabled dates. It only works when <a href="/docs/reference/additionally/settings#selection-day">`settings.selection.day`</a> is set to `'multiple-ranged'`.
+
+---
+
+## settings.range.edgesOnly
+
+`Type: Boolean`
+
+`Default: false`
+
+`Options: true | false`
+
+```js
+new VanillaCalendar('#calendar', {
+  settings: {
+    range: {
+      edgesOnly: true,
+    }
+  },
+});
+```
+
+This parameter will keep references of the date range edges only, which are the Start and End dates in `settings.selected.dates` but nothing in between the range. It only works when <a href="/docs/reference/additionally/settings#selection-day">`settings.selection.day`</a> is set to `'multiple-ranged'`.
+
+<Info>
+  It's important to note that with this setting, disabling dates within the date range will have no effect. So make sure to use this parameter when you are interested with only the start and end date but nothing in-between.
+</Info>
 
 ---
 

--- a/docs/en/reference/additionally/settings.mdx
+++ b/docs/en/reference/additionally/settings.mdx
@@ -115,6 +115,32 @@ This parameter sets the maximum date that the user can choose. Dates later than 
 
 ---
 
+## settings.range.edgesOnly
+
+`Type: Boolean`
+
+`Default: false`
+
+`Options: true | false`
+
+```js
+new VanillaCalendar('#calendar', {
+  settings: {
+    range: {
+      edgesOnly: true,
+    }
+  },
+});
+```
+
+This parameter will keep references of the date range edges only, which are the Start and End dates in `settings.selected.dates` but nothing in between the range. It only works when <a href="/docs/reference/additionally/settings#selection-day">`settings.selection.day`</a> is set to `'multiple-ranged'`.
+
+<Info>
+  It's important to note that with this setting, disabling dates within the date range will have no effect. So make sure to use this parameter when you are interested with only the start and end date but nothing in-between.
+</Info>
+
+---
+
 ## settings.range.disablePast
 
 `Type: Boolean`
@@ -156,32 +182,6 @@ new VanillaCalendar('#calendar', {
 ```
 
 This parameter disables the selection of days within a range with disabled dates. It only works when <a href="/docs/reference/additionally/settings#selection-day">`settings.selection.day`</a> is set to `'multiple-ranged'`.
-
----
-
-## settings.range.edgesOnly
-
-`Type: Boolean`
-
-`Default: false`
-
-`Options: true | false`
-
-```js
-new VanillaCalendar('#calendar', {
-  settings: {
-    range: {
-      edgesOnly: true,
-    }
-  },
-});
-```
-
-This parameter will keep references of the date range edges only, which are the Start and End dates in `settings.selected.dates` but nothing in between the range. It only works when <a href="/docs/reference/additionally/settings#selection-day">`settings.selection.day`</a> is set to `'multiple-ranged'`.
-
-<Info>
-  It's important to note that with this setting, disabling dates within the date range will have no effect. So make sure to use this parameter when you are interested with only the start and end date but nothing in-between.
-</Info>
 
 ---
 

--- a/docs/ru/reference/additionally/settings.mdx
+++ b/docs/ru/reference/additionally/settings.mdx
@@ -115,6 +115,32 @@ new VanillaCalendar('#calendar', {
 
 ---
 
+## settings.range.edgesOnly
+
+`Type: Boolean`
+
+`Default: false`
+
+`Options: true | false`
+
+```js
+new VanillaCalendar('#calendar', {
+  settings: {
+    range: {
+      edgesOnly: true,
+    }
+  },
+});
+```
+
+Этот параметр позволяет получить только начальную и конечную выбранную пользователем дату, игнорируя промежуточные даты. Этот параметр работает только в том случае, если для <a href="/docs/reference/additionally/settings#selection-day">`settings.selection.day`</a> установлено значение `'multiple-ranged'`.
+
+<Info>
+  Важно отметить, что при использовании этой настройки отключение дат в пределах диапазона дат не будет иметь никакого эффекта. Поэтому обязательно используйте этот параметр, если вас интересуют только начальная и конечная выбранная пользователем дата.
+</Info>
+
+---
+
 ## settings.range.disablePast
 
 `Type: Boolean`

--- a/package/src/scripts/default.ts
+++ b/package/src/scripts/default.ts
@@ -26,6 +26,7 @@ export default class DefaultOptionsCalendar {
 			max: this.date.max,
 			disablePast: false,
 			disableGaps: false,
+			edgesOnly: false,
 			disableAllDays: false,
 			disableWeekday: undefined,
 			disabled: undefined,

--- a/package/src/scripts/handles/handleDayRangedSelection.ts
+++ b/package/src/scripts/handles/handleDayRangedSelection.ts
@@ -87,9 +87,9 @@ const updateDisabledDates = () => {
 	const [startDate, endDate] = current.self.rangeDisabled
 		.map((dateStr) => getDate(dateStr))
 		.reduce<[Date | null, Date | null]>(([start, end], disabledDate) => [
-			selectedDate >= disabledDate ? disabledDate : start,
-			selectedDate < disabledDate && end === null ? disabledDate : end,
-		], [null, null]);
+		selectedDate >= disabledDate ? disabledDate : start,
+		selectedDate < disabledDate && end === null ? disabledDate : end,
+	], [null, null]);
 
 	if (startDate) current.self.rangeMin = getDateString(new Date(startDate.setDate(startDate.getDate() + 1)));
 	if (endDate) current.self.rangeMax = getDateString(new Date(endDate.setDate(endDate.getDate() - 1)));

--- a/package/src/scripts/handles/handleDayRangedSelection.ts
+++ b/package/src/scripts/handles/handleDayRangedSelection.ts
@@ -87,9 +87,9 @@ const updateDisabledDates = () => {
 	const [startDate, endDate] = current.self.rangeDisabled
 		.map((dateStr) => getDate(dateStr))
 		.reduce<[Date | null, Date | null]>(([start, end], disabledDate) => [
-		selectedDate >= disabledDate ? disabledDate : start,
-		selectedDate < disabledDate && end === null ? disabledDate : end,
-	], [null, null]);
+			selectedDate >= disabledDate ? disabledDate : start,
+			selectedDate < disabledDate && end === null ? disabledDate : end,
+		], [null, null]);
 
 	if (startDate) current.self.rangeMin = getDateString(new Date(startDate.setDate(startDate.getDate() + 1)));
 	if (endDate) current.self.rangeMax = getDateString(new Date(endDate.setDate(endDate.getDate() - 1)));
@@ -128,7 +128,9 @@ const handleDayRangedSelection = (self: VanillaCalendar, formattedDate?: FormatD
 		reset: () => {
 			const [startDate, endDate] = [self.selectedDates[0], self.selectedDates[self.selectedDates.length - 1]];
 			self.selectedDates = self.selectedDates[0] !== self.selectedDates[self.selectedDates.length - 1]
-				? parseDates([`${startDate as string}:${endDate as string}`])
+				? self.settings.range.edgesOnly
+					? [startDate, endDate]
+					: parseDates([`${startDate as string}:${endDate as string}`])
 				: [self.selectedDates[0], self.selectedDates[0]];
 			self.HTMLElement.removeEventListener('mousemove', handleHoverDaysEvent);
 			document.removeEventListener('keydown', handleCancelSelectionDays);

--- a/package/src/scripts/methods/createDays.ts
+++ b/package/src/scripts/methods/createDays.ts
@@ -65,6 +65,18 @@ const setDayModifier = (
 			}
 		}
 	}
+
+	// when using multiple-ranged with range edges only (only includes start/end selected dates)
+	if (self.settings.range.edgesOnly && self.selectedDates.length > 1 && self.settings.selection.day === 'multiple-ranged') {
+		const firstDate = +new Date(self.selectedDates[0]);
+		const lastDate = +new Date(self.selectedDates[self.selectedDates.length - 1]);
+		const nextDate = +new Date(date);
+
+		if (nextDate > firstDate && nextDate < lastDate) {
+			dayBtnEl.classList.add(self.CSSClasses.dayBtnSelected);
+			dayEl.classList.add(self.CSSClasses.daySelectedIntermediate);
+		}
+	}
 };
 
 const createDay = (

--- a/package/types.ts
+++ b/package/types.ts
@@ -31,7 +31,7 @@ export interface IRange {
 	 * This parameter will only keep references of the date range edges (start/end dates) in the `settings.selected.dates` array.
 	 * Only works when `settings.selection.day` is set to `'multiple-ranged'`.
 	 */
-	edgesOnly: boolean;
+	edgesOnly?: boolean;
 	/** This parameter disables all days and can be useful when using `settings.range.enabled` */
 	disableAllDays: boolean;
 	/** This parameter allows you to disable specified weekdays. */

--- a/package/types.ts
+++ b/package/types.ts
@@ -16,13 +16,29 @@ export interface IDates {
 }
 
 export interface IRange {
+	/** This parameter sets the minimum date that the user can choose */
 	min: FormatDateString | 'today';
+	/** This parameter sets the maximum date that the user can choose */
 	max: FormatDateString | 'today';
+	/** This parameter disables all past days. */
 	disablePast: boolean;
+	/**
+	 * This parameter disables the selection of days within a range with disabled dates.
+	 * Only works when `settings.selection.day` is set to `'multiple-ranged'`.
+	 */
 	disableGaps: boolean;
+	/**
+	 * This parameter will only keep references of the date range edges (start/end dates) in the `settings.selected.dates` array.
+	 * Only works when `settings.selection.day` is set to `'multiple-ranged'`.
+	 */
+	edgesOnly: boolean;
+	/** This parameter disables all days and can be useful when using `settings.range.enabled` */
 	disableAllDays: boolean;
+	/** This parameter allows you to disable specified weekdays. */
 	disableWeekday?: number[];
+	/** This parameter allows you to disable specific dates regardless of the specified range. */
 	disabled?: string[];
+	/** This parameter allows you to enable specific dates regardless of the range and disabled dates. */
 	enabled?: string[];
 }
 


### PR DESCRIPTION
- when using `multiple-ranged`, it will by default push **all** the range dates in the `settings.selected.dates`, however in some cases we are sometime only interested in the Start/End dates (first & last). For example, if we have a range of Jan 1st to Feb 28, it will push 59 days to the `settings.selected.dates` array, however with `edgesOnly`, it will only push 2 dates in the array which are equal to the Start/End dates
- for a project like mine with a data grid, I'm only interested in the Start/End dates so that I can use it to filter my grid data by comparing dates between X start date and Y end date. So I'm really only interested in the edges (start/end) and I don't care about the dates that are in the middle, I really don't need to know what the dates are in the middle dates since the start/end is all I really need (hence why I'm adding this new feature)
- this option can be extremely useful when the user selects a date range that spans over multiple months (6 months or 1 year range would create a very large array of selected dates, when in reality we sometime just want to know the date range start/end dates for filtering purposes or anything similar)
- Note: I'm already using this code in production from my fork of your project, I hope to switch back to your original project as soon as all my PRs are hopefully accepted :)

Below is an example making a date range selection which starts on April 4th and ends on April 14th

![image](https://github.com/user-attachments/assets/95832887-c993-48f9-9c3d-72b4e1b76405)

with `edgesOnly: true`, it will return only 2 dates in the array, the start & ending dates. I can then call this simple line of code to retrieve start/end dates `const [start, end] = self.selectedDates;`

![image](https://github.com/user-attachments/assets/6e4097f0-264b-4cde-ba76-2965480b41a5)

but without `edgesOnly` (`false` or `undefined` which is the default), it will return **all dates** in the array

![image](https://github.com/user-attachments/assets/bad92e39-7526-49ae-b8e4-9db92859a07b)
