### PR TITLE
fix: ViteJS has problems finding CSS file from package exports

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -51,10 +51,8 @@
 		},
 		"./types": "./types.ts",
 		"./package.json": "./package.json",
-		"./build/vanilla-calendar.min.css": "./build/vanilla-calendar.min.css",
-		"./build/vanilla-calendar.layout.min.css": "./build/vanilla-calendar.layout.min.css",
-		"./build/themes/light.min.css": "./build/themes/light.min.css",
-		"./build/themes/dark.min.css": "./build/themes/dark.min.css"
+		"./build/*": "./build/*",
+		"./build/themes/*": "./build/themes/*"
 	},
 	"devDependencies": {},
 	"dependencies": {}


### PR DESCRIPTION
- Vite was throwing this error which was a problem identified in the package exports, we can use the `*` wildcard to include any file from that folder
> "vanilla-calendar.min" when using `@import vanilla-calendar.min` (without the file extension). We can simply use the * wildcard to fix the issue

if you go on [Are the types wrong?](https://arethetypeswrong.github.io/?p=vanilla-calendar-pro), you can see that the CSS are showing are resolution failed. This PR fixes this problem which is detected when using ViteJS

![image](https://github.com/user-attachments/assets/ebe938f5-1c13-436d-bb8e-ebc00214125c)
