### PR TITLE
fix: cross platform compatibility, make sure `replaceWith()` exists before using it

### DIFF
--- a/package/src/scripts/destroy.ts
+++ b/package/src/scripts/destroy.ts
@@ -6,10 +6,10 @@ const destroy = (self: VanillaCalendar) => {
 
 	if (self.input) {
 		self.HTMLElement?.parentElement?.removeChild(self.HTMLElement);
-		self.HTMLInputElement?.replaceWith(self.HTMLOriginalElement);
+		self.HTMLInputElement?.replaceWith?.(self.HTMLOriginalElement);
 		self.HTMLInputElement = undefined;
 	} else {
-		self.HTMLElement?.replaceWith(self.HTMLOriginalElement);
+		self.HTMLElement?.replaceWith?.(self.HTMLOriginalElement);
 	}
 
 	self.HTMLElement = self.HTMLOriginalElement;


### PR DESCRIPTION
- fixes another cross platform compatibility issue
- `replaceWith` doesn't seem to be supported in the Salesforce environment (throws an error), we can simply add checks to make sure it is a function that exists before trying to call the function