### PR TITLE
feat: add `auto` option to `positionToInput` for auto-positioning

### DIFF
--- a/docs/en/reference/additionally/settings.mdx
+++ b/docs/en/reference/additionally/settings.mdx
@@ -739,7 +739,7 @@ With this parameter, you can decide whether to display days from the previous an
 new VanillaCalendar('#calendar', {
   settings: {
     visibility: {
-      positionToInput: 'center',
+      positionToInput: 'auto',
       // positionToInput: ['bottom', 'center'],
     },
   },

--- a/docs/en/reference/additionally/settings.mdx
+++ b/docs/en/reference/additionally/settings.mdx
@@ -733,7 +733,7 @@ With this parameter, you can decide whether to display days from the previous an
 
 `Default: 'left'`
 
-`Options: 'left' | 'center' | 'right' | ['bottom', 'left'] | ['bottom', 'center'] | ['bottom', 'right'] | ['top', 'left'] | ['top', 'center'] | ['top', 'right']`
+`Options: 'auto' | 'center' | 'left' | 'right' | ['bottom' | 'top', 'center' | 'left' | 'right']`
 
 ```js
 new VanillaCalendar('#calendar', {
@@ -750,3 +750,7 @@ This parameter specifies the position of the calendar relative to input, if the 
 
 `positionToInput` takes a string with a value of `'left'`, `'center'`, or `'right'`, or an array of values `[Y-axis, X-axis]`, where the Y-axis can take the values `'bottom'` or `'top'`, and the X-axis can take the values `'left'`, `'center'`, or `'right'`.
 If the Y-axis is not specified, the default is `'bottom'`.
+
+You can use the `positionToInput: 'auto'` value to automatically detect the best position depending on the available space in the viewport. 
+Behind the scene, it calculates the available space on all 4 sides, and it will first try to display the picker at the bottom of the input
+which is the default position. If there is not enough space at the bottom, it will evaluate what would be the other best available position.

--- a/docs/en/reference/main/main-settings.mdx
+++ b/docs/en/reference/main/main-settings.mdx
@@ -44,7 +44,7 @@ The `type` parameter determines the type of calendar displayed.
 
 `Default: 2`
 
-`Options: от 2 до 12`
+`Options: from 2 to 12`
 
 ```js
 new VanillaCalendar('#calendar', {
@@ -62,7 +62,7 @@ The `months` parameter specifies the number of displayed months when the calenda
 
 `Default: 1`
 
-`Options: от 1 до ∞`
+`Options: from 1 to ∞`
 
 ```js
 new VanillaCalendar('#calendar', {

--- a/docs/ru/reference/additionally/settings.mdx
+++ b/docs/ru/reference/additionally/settings.mdx
@@ -734,13 +734,13 @@ new VanillaCalendar('#calendar', {
 
 `Default: 'left'`
 
-`Options: 'left' | 'center' | 'right' | ['bottom', 'left'] | ['bottom', 'center'] | ['bottom', 'right'] | ['top', 'left'] | ['top', 'center'] | ['top', 'right']`
+`Options: 'auto' | 'center' | 'left' | 'right' | ['bottom' | 'top', 'center' | 'left' | 'right']`
 
 ```js
 new VanillaCalendar('#calendar', {
   settings: {
     visibility: {
-      positionToInput: 'center',
+      positionToInput: 'auto',
       // positionToInput: ['bottom', 'center'],
     },
   },
@@ -751,3 +751,7 @@ new VanillaCalendar('#calendar', {
 
 `positionToInput` принимает строку со значением `'left'`, `'center'` или `'right'`, либо массив значений `[ось Y, ось X]`, где ось Y может быть `'bottom'` или `'top'`, а ось X может быть `'left'`, `'center'` или `'right'`.
 Если ось Y не указана, то используется значение по умолчанию - `'bottom'`.
+
+Вы можете использовать значение `positionToInput: 'auto'` для автоматического определения наилучшей позиции в зависимости от доступного места в области просмотра.
+Опция позволяет рассчитать доступное пространство со всех 4 сторон и сначала попытается отобразить календарь внизу относительно input, это позиция по умолчанию.
+Если внизу недостаточно места, он оценит другую лучшую доступную позицию.

--- a/package/src/scripts/handles/handleClickWeekNumber.ts
+++ b/package/src/scripts/handles/handleClickWeekNumber.ts
@@ -10,7 +10,7 @@ const handleClickWeekNumber = (self: VanillaCalendar, event: MouseEvent) => {
 
 	const weekNumberValue = Number(weekNumberEl.innerText);
 	const yearWeek = Number(weekNumberEl.dataset.calendarYearWeek);
-	const daysOfThisWeek = [...daysToWeeks].filter((day) => Number((day as HTMLElement).dataset.calendarWeekNumber) === weekNumberValue);
+	const daysOfThisWeek = Array.from(daysToWeeks).filter((day) => Number((day as HTMLElement).dataset.calendarWeekNumber) === weekNumberValue);
 
 	self.actions.clickWeekNumber(event, weekNumberValue, daysOfThisWeek, yearWeek, self);
 };

--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -1,7 +1,7 @@
 import VanillaCalendar from '@src/vanilla-calendar';
 import handleClick from '@scripts/handles/handleClick';
 import reset from '@scripts/reset';
-import { findBestPickerPosition } from '@scripts/helpers/position';
+import { findBestPickerPosition, getOffset } from '@scripts/helpers/position';
 import { IVisibility, CSSClasses } from '@/package/types';
 
 const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
@@ -21,14 +21,18 @@ const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTML
 		const YPosition = !Array.isArray(pos) ? 'bottom' : pos[0];
 		const XPosition = !Array.isArray(pos) ? pos : pos[1];
 
-		calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
+		// add CSS class to extra margin but make sure to only keep 1 class and remove previous one
+		if (YPosition === 'bottom') {
+			calendar.classList.remove(css.calendarToInputTop);
+			calendar.classList.add(css.calendarToInputBottom);
+		} else {
+			calendar.classList.remove(css.calendarToInputBottom);
+			calendar.classList.add(css.calendarToInputTop);
+		}
 
-		const inputRect = input.getBoundingClientRect();
-		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-		const scrollTop = window.scrollY || document.documentElement.scrollTop;
-
-		const top = inputRect.top + scrollTop + getPosition[YPosition];
-		const left = inputRect.left + scrollLeft + getPosition[XPosition];
+		const { top: offsetTop, left: offsetLeft } = getOffset(input);
+		const top = offsetTop + getPosition[YPosition];
+		const left = offsetLeft + getPosition[XPosition];
 
 		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
 	}

--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -1,8 +1,8 @@
 import VanillaCalendar from '@src/vanilla-calendar';
 import handleClick from '@scripts/handles/handleClick';
 import reset from '@scripts/reset';
+import { findBestPickerPosition } from '@scripts/helpers/position';
 import { IVisibility, CSSClasses } from '@/package/types';
-import { findBestPickerPosition } from '../helpers/position';
 
 const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
 	if (input) {

--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -2,31 +2,36 @@ import VanillaCalendar from '@src/vanilla-calendar';
 import handleClick from '@scripts/handles/handleClick';
 import reset from '@scripts/reset';
 import { IVisibility, CSSClasses } from '@/package/types';
+import { findBestPickerPosition } from '../helpers/position';
 
 const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
-	if (!input) return;
+	if (input) {
+		const pos = position === 'auto'
+			? findBestPickerPosition(input, calendar)
+			: position;
 
-	const getPosition = {
-		top: -calendar.offsetHeight,
-		bottom: input.offsetHeight,
-		left: 0,
-		center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
-		right: input.offsetWidth - calendar.offsetWidth,
-	};
+		const getPosition = {
+			top: -calendar.offsetHeight,
+			bottom: input.offsetHeight,
+			left: 0,
+			center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
+			right: input.offsetWidth - calendar.offsetWidth,
+		};
 
-	const YPosition = !Array.isArray(position) ? 'bottom' : position[0];
-	const XPosition = !Array.isArray(position) ? position : position[1];
+		const YPosition = !Array.isArray(pos) ? 'bottom' : pos[0];
+		const XPosition = !Array.isArray(pos) ? pos : pos[1];
 
-	calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
+		calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
 
-	const inputRect = input.getBoundingClientRect();
-	const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-	const scrollTop = window.scrollY || document.documentElement.scrollTop;
+		const inputRect = input.getBoundingClientRect();
+		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+		const scrollTop = window.scrollY || document.documentElement.scrollTop;
 
-	const top = inputRect.top + scrollTop + getPosition[YPosition];
-	const left = inputRect.left + scrollLeft + getPosition[XPosition];
+		const top = inputRect.top + scrollTop + getPosition[YPosition];
+		const left = inputRect.left + scrollLeft + getPosition[XPosition];
 
-	Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
+		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
+	}
 };
 
 const handleInput = (self: VanillaCalendar) => {
@@ -41,8 +46,13 @@ const handleInput = (self: VanillaCalendar) => {
 		document.body.appendChild(self.HTMLElement);
 		firstInit = false;
 
+		// because of a positioning delay, it might flicker for a short period
+		// we can hide the picker, reposition it, and finally show it back to avoid flickering because of the positioning delay below
+		self.HTMLElement.style.visibility = 'hidden';
+
 		setTimeout(() => {
 			setPositionCalendar(self.HTMLInputElement, calendar, self.settings.visibility.positionToInput, self.CSSClasses);
+			self.HTMLElement.style.visibility = 'visible';
 			self.show();
 		}, 0);
 		reset(self, {
@@ -71,10 +81,8 @@ const handleInput = (self: VanillaCalendar) => {
 		window.addEventListener('resize', handleResize);
 		document.addEventListener('click', documentClickEvent, { capture: true });
 	});
-
 	return () => {
 		cleanup.forEach((clean) => clean());
 	};
 };
-
 export default handleInput;

--- a/package/src/scripts/helpers/getColumnID.ts
+++ b/package/src/scripts/helpers/getColumnID.ts
@@ -2,7 +2,7 @@ import VanillaCalendar from '@src/vanilla-calendar';
 
 const getColumnID = (self: VanillaCalendar, columnClass: string, personalClass: string, id: number, dataAttr: string) => {
 	const columnEls: NodeListOf<HTMLElement> = self.HTMLElement.querySelectorAll(`.${self.CSSClasses.column}`);
-	const indexColumn = [...columnEls].findIndex((column) => column.classList.contains(columnClass));
+	const indexColumn = Array.from(columnEls).findIndex((column) => column.classList.contains(columnClass));
 	const currentValue = Number((columnEls[indexColumn].querySelector(`.${personalClass}`) as HTMLElement).getAttribute(dataAttr));
 
 	if (self.currentType === 'month' && indexColumn >= 0) return id - indexColumn;

--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -1,4 +1,4 @@
-import { CSSClasses, IVisibility, HtmlElementPosition } from '@/package/types';
+import { HtmlElementPosition } from '@/package/types';
 
 type Position = 'center' | 'left' | 'right';
 type PositionList = ['bottom' | 'top', 'center' | 'left' | 'right'];

--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -1,0 +1,165 @@
+import { CSSClasses, IVisibility, HtmlElementPosition } from '@/package/types';
+
+type Position = 'center' | 'left' | 'right';
+type PositionList = ['bottom' | 'top', 'center' | 'left' | 'right'];
+
+/** Get HTML element offset with pure JS */
+export function getOffset(elm?: HTMLElement | null): HtmlElementPosition | undefined {
+	if (!elm || !elm.getBoundingClientRect) {
+		return undefined;
+	}
+	const box = elm.getBoundingClientRect();
+	const docElem = document.documentElement;
+
+	return {
+		bottom: box.bottom,
+		right: box.right,
+		top: box.top + window.pageYOffset - docElem.clientTop,
+		left: box.left + window.pageXOffset - docElem.clientLeft,
+	};
+}
+
+/**
+ * Get the Window Scroll top/left Position
+ * @returns
+ */
+export function windowScrollPosition(): { left: number; top: number; } {
+	return {
+		left: window.pageXOffset || document.documentElement.scrollLeft || 0,
+		top: window.pageYOffset || document.documentElement.scrollTop || 0,
+	};
+}
+
+export function getViewportDimensions() {
+	return {
+		vw: Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0),
+		vh: Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0),
+	};
+}
+
+/** calculate available space for each side of the DOM element */
+export function calculateAvailableSpace(element: HTMLElement): { top: number; bottom: number; left: number; right: number; } {
+	let bottom = 0;
+	let top = 0;
+	let left = 0;
+	let right = 0;
+
+	const scrollPosition = windowScrollPosition();
+	const elmOffset = getOffset(element);
+	const { vh, vw } = getViewportDimensions();
+	const pageScrollTop = scrollPosition.top;
+	const pageScrollLeft = scrollPosition.left;
+
+	if (elmOffset) {
+		const elementOffsetTop = elmOffset.top ?? 0;
+		const elementOffsetLeft = elmOffset.left ?? 0;
+		top = elementOffsetTop - pageScrollTop;
+		left = elementOffsetLeft - pageScrollLeft;
+		bottom = vh - (elementOffsetTop - pageScrollTop + element.clientHeight);
+		right = vw - (elementOffsetLeft - pageScrollLeft + element.clientWidth);
+	}
+
+	return { top, bottom, left, right };
+}
+
+/**
+ * Get all available positions calculated by available space,
+ * e.g.: { canShow: { top: true, bottom: false, ...}, parentPositions: ['top', 'center'] }
+ * @param parentElm - parent element (input)
+ * @param pickerElm - picker element (calendar picker modal)
+ * @param marginOffset - margin offset when picker is opened
+ * @returns
+ */
+export function getAvailablePosition(parentElm: HTMLElement, pickerElm: HTMLElement, marginOffset = 5) {
+	const canShow = { top: true, bottom: true, left: true, right: true };
+	const parentPositions: PositionList = [] as unknown as PositionList;
+
+	if (pickerElm && parentElm) {
+		const { bottom: spaceBottom, top: spaceTop } = calculateAvailableSpace(parentElm);
+		const { top: pickerOffsetTop, left: pickerOffsetLeft } = getOffset(parentElm) as HtmlElementPosition;
+		const { height: pickerHeight, width: pickerWidth } = pickerElm.getBoundingClientRect();
+		const { vh, vw } = getViewportDimensions();
+		const bodyCenterCoordinate = { x: vw / 2, y: vh / 2 };
+
+		if (pickerOffsetTop < bodyCenterCoordinate.y) {
+			parentPositions.push('top');
+		}
+		if (pickerOffsetTop > bodyCenterCoordinate.y) {
+			parentPositions.push('bottom');
+		}
+		if (pickerOffsetLeft < bodyCenterCoordinate.x) {
+			parentPositions.push('left');
+		}
+		if (pickerOffsetLeft > bodyCenterCoordinate.x) {
+			parentPositions.push('right');
+		}
+
+		if (pickerHeight > (spaceTop - marginOffset)) {
+			canShow.top = false;
+		}
+		if (pickerHeight > (spaceBottom - marginOffset)) {
+			canShow.bottom = false;
+		}
+		if (pickerWidth > pickerOffsetLeft) {
+			canShow.left = false;
+		}
+		if ((vw - pickerOffsetLeft) < pickerWidth) {
+			canShow.right = false;
+		}
+	}
+
+	return { canShow, parentPositions };
+}
+
+export function findBestPickerPosition(input: HTMLInputElement, calendar: HTMLElement): Position | PositionList {
+	let position: Position | PositionList = 'left';
+	if (calendar && input) {
+		const { canShow, parentPositions } = getAvailablePosition(input, calendar);
+
+		if (canShow.left && canShow.right) {
+			if (canShow.bottom) {
+				position = 'center';
+			} else if (canShow.top) {
+				position = ['top', 'center'];
+			}
+		} else {
+			if (Array.isArray(parentPositions)) {
+				parentPositions[0] = (parentPositions[0] === 'bottom') ? 'top' : 'bottom';
+				return parentPositions;
+			}
+			return parentPositions;
+		}
+	}
+
+	return position;
+}
+
+export const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
+	if (input) {
+		const pos = position === 'auto'
+			? findBestPickerPosition(input, calendar)
+			: position;
+
+		const getPosition = {
+			top: -calendar.offsetHeight,
+			bottom: input.offsetHeight,
+			left: 0,
+			center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
+			right: input.offsetWidth - calendar.offsetWidth,
+		};
+
+		const YPosition = !Array.isArray(pos) ? 'bottom' : pos[0];
+		const XPosition = !Array.isArray(pos) ? pos : pos[1];
+
+		calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
+
+		const inputRect = input.getBoundingClientRect();
+		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+		const scrollTop = window.scrollY || document.documentElement.scrollTop;
+
+		const top = inputRect.top + scrollTop + getPosition[YPosition];
+		const left = inputRect.left + scrollLeft + getPosition[XPosition];
+
+		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
+	}
+};

--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -4,9 +4,9 @@ type Position = 'center' | 'left' | 'right';
 type PositionList = ['bottom' | 'top', 'center' | 'left' | 'right'];
 
 /** Get HTML element offset with pure JS */
-export function getOffset(elm?: HTMLElement | null): HtmlElementPosition | undefined {
+export function getOffset(elm?: HTMLElement | null): HtmlElementPosition {
 	if (!elm || !elm.getBoundingClientRect) {
-		return undefined;
+		return { top: 0, bottom: 0, left: 0, right: 0 };
 	}
 	const box = elm.getBoundingClientRect();
 	const docElem = document.documentElement;
@@ -51,8 +51,8 @@ export function calculateAvailableSpace(element: HTMLElement): { top: number; bo
 	const pageScrollLeft = scrollPosition.left;
 
 	if (elmOffset) {
-		const elementOffsetTop = elmOffset.top ?? 0;
-		const elementOffsetLeft = elmOffset.left ?? 0;
+		const elementOffsetTop = elmOffset.top;
+		const elementOffsetLeft = elmOffset.left;
 		top = elementOffsetTop - pageScrollTop;
 		left = elementOffsetLeft - pageScrollLeft;
 		bottom = vh - (elementOffsetTop - pageScrollTop + element.clientHeight);

--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -6,7 +6,9 @@ type PositionList = ['bottom' | 'top', 'center' | 'left' | 'right'];
 /** Get HTML element offset with pure JS */
 export function getOffset(elm?: HTMLElement | null): HtmlElementPosition {
 	if (!elm || !elm.getBoundingClientRect) {
-		return { top: 0, bottom: 0, left: 0, right: 0 };
+		return {
+			top: 0, bottom: 0, left: 0, right: 0,
+		};
 	}
 	const box = elm.getBoundingClientRect();
 	const docElem = document.documentElement;
@@ -14,8 +16,8 @@ export function getOffset(elm?: HTMLElement | null): HtmlElementPosition {
 	return {
 		bottom: box.bottom,
 		right: box.right,
-		top: box.top + window.pageYOffset - docElem.clientTop,
-		left: box.left + window.pageXOffset - docElem.clientLeft,
+		top: box.top + window.scrollY - docElem.clientTop,
+		left: box.left + window.scrollX - docElem.clientLeft,
 	};
 }
 
@@ -25,8 +27,8 @@ export function getOffset(elm?: HTMLElement | null): HtmlElementPosition {
  */
 export function windowScrollPosition(): { left: number; top: number; } {
 	return {
-		left: window.pageXOffset || document.documentElement.scrollLeft || 0,
-		top: window.pageYOffset || document.documentElement.scrollTop || 0,
+		left: window.scrollX || document.documentElement.scrollLeft || 0,
+		top: window.scrollY || document.documentElement.scrollTop || 0,
 	};
 }
 
@@ -59,7 +61,9 @@ export function calculateAvailableSpace(element: HTMLElement): { top: number; bo
 		right = vw - (elementOffsetLeft - pageScrollLeft + element.clientWidth);
 	}
 
-	return { top, bottom, left, right };
+	return {
+		top, bottom, left, right,
+	};
 }
 
 /**
@@ -71,7 +75,9 @@ export function calculateAvailableSpace(element: HTMLElement): { top: number; bo
  * @returns
  */
 export function getAvailablePosition(parentElm: HTMLElement, pickerElm: HTMLElement, marginOffset = 5) {
-	const canShow = { top: true, bottom: true, left: true, right: true };
+	const canShow = {
+		top: true, bottom: true, left: true, right: true,
+	};
 	const parentPositions: PositionList = [] as unknown as PositionList;
 
 	if (pickerElm && parentElm) {

--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -133,33 +133,3 @@ export function findBestPickerPosition(input: HTMLInputElement, calendar: HTMLEl
 
 	return position;
 }
-
-export const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
-	if (input) {
-		const pos = position === 'auto'
-			? findBestPickerPosition(input, calendar)
-			: position;
-
-		const getPosition = {
-			top: -calendar.offsetHeight,
-			bottom: input.offsetHeight,
-			left: 0,
-			center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
-			right: input.offsetWidth - calendar.offsetWidth,
-		};
-
-		const YPosition = !Array.isArray(pos) ? 'bottom' : pos[0];
-		const XPosition = !Array.isArray(pos) ? pos : pos[1];
-
-		calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
-
-		const inputRect = input.getBoundingClientRect();
-		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-		const scrollTop = window.scrollY || document.documentElement.scrollTop;
-
-		const top = inputRect.top + scrollTop + getPosition[YPosition];
-		const left = inputRect.left + scrollLeft + getPosition[XPosition];
-
-		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
-	}
-};

--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -1,16 +1,18 @@
-import { HtmlElementPosition } from '@/package/types';
+import { HtmlElementPosition, Positions } from '@package/types';
 
-type Position = 'center' | 'left' | 'right';
-type PositionList = ['bottom' | 'top', 'center' | 'left' | 'right'];
-
-/** Get HTML element offset with pure JS */
-export function getOffset(elm?: HTMLElement | null): HtmlElementPosition {
-	if (!elm || !elm.getBoundingClientRect) {
+/**
+ * Get the offset position of an HTML element relative to the viewport.
+ * @param {HTMLElement | null} element - The HTML element whose position is to be calculated.
+ * @returns {HtmlElementPosition} An object containing the top, bottom, left, and right offset positions of the element.
+ */
+export function getOffset(element?: HTMLElement | null): HtmlElementPosition {
+	if (!element || !element.getBoundingClientRect) {
 		return {
 			top: 0, bottom: 0, left: 0, right: 0,
 		};
 	}
-	const box = elm.getBoundingClientRect();
+
+	const box = element.getBoundingClientRect();
 	const docElem = document.documentElement;
 
 	return {
@@ -22,16 +24,20 @@ export function getOffset(elm?: HTMLElement | null): HtmlElementPosition {
 }
 
 /**
- * Get the Window Scroll top/left Position
- * @returns
+ * Get the current scroll position of the window.
+ * @returns {{ left: number, top: number }} An object containing the horizontal (left) and vertical (top) scroll positions.
  */
-export function windowScrollPosition(): { left: number; top: number; } {
+export function getWindowScrollPosition(): { left: number; top: number; } {
 	return {
 		left: window.scrollX || document.documentElement.scrollLeft || 0,
 		top: window.scrollY || document.documentElement.scrollTop || 0,
 	};
 }
 
+/**
+ * Get the dimensions of the viewport.
+ * @returns {{ vw: number; vh: number; }} An object containing the viewport width (`vw`) and height (`vh`).
+ */
 export function getViewportDimensions() {
 	return {
 		vw: Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0),
@@ -39,103 +45,92 @@ export function getViewportDimensions() {
 	};
 }
 
-/** calculate available space for each side of the DOM element */
+/**
+ * Calculates the available space for each side of the DOM element.
+ * @param {HTMLElement} element - The DOM element to calculate space for.
+ * @returns {{ top: number, bottom: number, left: number, right: number }} An object containing the available space on the top, bottom, left, and right sides of the element.
+ */
 export function calculateAvailableSpace(element: HTMLElement): { top: number; bottom: number; left: number; right: number; } {
-	let bottom = 0;
-	let top = 0;
-	let left = 0;
-	let right = 0;
+	const { top: scrollTop, left: scrollLeft } = getWindowScrollPosition();
+	const { top: elementTop, left: elementLeft } = getOffset(element);
+	const { vh: viewportHeight, vw: viewportWidth } = getViewportDimensions();
 
-	const scrollPosition = windowScrollPosition();
-	const elmOffset = getOffset(element);
-	const { vh, vw } = getViewportDimensions();
-	const pageScrollTop = scrollPosition.top;
-	const pageScrollLeft = scrollPosition.left;
-
-	if (elmOffset) {
-		const elementOffsetTop = elmOffset.top;
-		const elementOffsetLeft = elmOffset.left;
-		top = elementOffsetTop - pageScrollTop;
-		left = elementOffsetLeft - pageScrollLeft;
-		bottom = vh - (elementOffsetTop - pageScrollTop + element.clientHeight);
-		right = vw - (elementOffsetLeft - pageScrollLeft + element.clientWidth);
-	}
+	const elementOffsetTop = elementTop - scrollTop;
+	const elementOffsetLeft = elementLeft - scrollLeft;
 
 	return {
-		top, bottom, left, right,
+		top: elementOffsetTop,
+		bottom: viewportHeight - (elementOffsetTop + element.clientHeight),
+		left: elementOffsetLeft,
+		right: viewportWidth - (elementOffsetLeft + element.clientWidth),
 	};
 }
 
 /**
- * Get all available positions calculated by available space,
- * e.g.: { canShow: { top: true, bottom: false, ...}, parentPositions: ['top', 'center'] }
- * @param parentElm - parent element (input)
- * @param pickerElm - picker element (calendar picker modal)
- * @param marginOffset - margin offset when picker is opened
- * @returns
+ * Determines available positions for displaying a picker element relative to a parent element,
+ * considering available space and margin offset.
+ * @param {HTMLElement} parentElm - The input element.
+ * @param {HTMLElement} pickerElm - The calendar picker modal.
+ * @param {number} marginOffset - Margin offset applied when the picker is opened.
+ * @returns {{ canShow: { top: boolean, bottom: boolean, left: boolean, right: boolean }, parentPositions: Positions[] }}
+ * An object containing the possible display positions and parent element positions.
  */
-export function getAvailablePosition(parentElm: HTMLElement, pickerElm: HTMLElement, marginOffset = 5) {
+export function getAvailablePosition(parentElm: HTMLInputElement, pickerElm: HTMLElement, marginOffset = 5) {
 	const canShow = {
-		top: true, bottom: true, left: true, right: true,
+		top: true,
+		bottom: true,
+		left: true,
+		right: true,
 	};
-	const parentPositions: PositionList = [] as unknown as PositionList;
+	const parentPositions: Positions[] = [];
 
-	if (pickerElm && parentElm) {
-		const { bottom: spaceBottom, top: spaceTop } = calculateAvailableSpace(parentElm);
-		const { top: pickerOffsetTop, left: pickerOffsetLeft } = getOffset(parentElm) as HtmlElementPosition;
-		const { height: pickerHeight, width: pickerWidth } = pickerElm.getBoundingClientRect();
-		const { vh, vw } = getViewportDimensions();
-		const bodyCenterCoordinate = { x: vw / 2, y: vh / 2 };
+	if (!pickerElm || !parentElm) return { canShow, parentPositions };
 
-		if (pickerOffsetTop < bodyCenterCoordinate.y) {
-			parentPositions.push('top');
-		}
-		if (pickerOffsetTop > bodyCenterCoordinate.y) {
-			parentPositions.push('bottom');
-		}
-		if (pickerOffsetLeft < bodyCenterCoordinate.x) {
-			parentPositions.push('left');
-		}
-		if (pickerOffsetLeft > bodyCenterCoordinate.x) {
-			parentPositions.push('right');
-		}
+	const { bottom: spaceBottom, top: spaceTop } = calculateAvailableSpace(parentElm);
+	const { top: pickerOffsetTop, left: pickerOffsetLeft } = getOffset(parentElm);
+	const { height: pickerHeight, width: pickerWidth } = pickerElm.getBoundingClientRect();
+	const { vh, vw } = getViewportDimensions();
+	const bodyCenterCoordinate = { x: vw / 2, y: vh / 2 };
 
-		if (pickerHeight > (spaceTop - marginOffset)) {
-			canShow.top = false;
-		}
-		if (pickerHeight > (spaceBottom - marginOffset)) {
-			canShow.bottom = false;
-		}
-		if (pickerWidth > pickerOffsetLeft) {
-			canShow.left = false;
-		}
-		if ((vw - pickerOffsetLeft) < pickerWidth) {
-			canShow.right = false;
-		}
-	}
+	const positionMappings: Array<{ condition: boolean, position: Positions }> = [
+		{ condition: pickerOffsetTop < bodyCenterCoordinate.y, position: 'top' },
+		{ condition: pickerOffsetTop > bodyCenterCoordinate.y, position: 'bottom' },
+		{ condition: pickerOffsetLeft < bodyCenterCoordinate.x, position: 'left' },
+		{ condition: pickerOffsetLeft > bodyCenterCoordinate.x, position: 'right' },
+	];
+
+	positionMappings.forEach(({ condition, position }) => {
+		if (condition) parentPositions.push(position);
+	});
+
+	Object.assign(canShow, {
+		top: pickerHeight <= (spaceTop - marginOffset),
+		bottom: pickerHeight <= (spaceBottom - marginOffset),
+		left: pickerWidth <= pickerOffsetLeft,
+		right: pickerWidth <= (vw - pickerOffsetLeft),
+	});
 
 	return { canShow, parentPositions };
 }
 
-export function findBestPickerPosition(input: HTMLInputElement, calendar: HTMLElement): Position | PositionList {
-	let position: Position | PositionList = 'left';
-	if (calendar && input) {
-		const { canShow, parentPositions } = getAvailablePosition(input, calendar);
+/**
+ * Determines the best position for displaying a calendar picker relative to an input element.
+ * @param {HTMLInputElement} input - The input element.
+ * @param {HTMLElement} calendar - The calendar picker modal.
+ * @returns {Positions | Positions[]} The best position(s) for the calendar picker modal.
+ */
+export function findBestPickerPosition(input: HTMLInputElement, calendar: HTMLElement): Positions | Positions[] {
+	const position: Positions | Positions[] = 'left';
 
-		if (canShow.left && canShow.right) {
-			if (canShow.bottom) {
-				position = 'center';
-			} else if (canShow.top) {
-				position = ['top', 'center'];
-			}
-		} else {
-			if (Array.isArray(parentPositions)) {
-				parentPositions[0] = (parentPositions[0] === 'bottom') ? 'top' : 'bottom';
-				return parentPositions;
-			}
-			return parentPositions;
-		}
-	}
+	if (!calendar || !input) return position;
 
-	return position;
+	const { canShow, parentPositions } = getAvailablePosition(input, calendar);
+	const isCenterPosition = canShow.left && canShow.right;
+
+	const bestPosition: Positions | Positions[] = isCenterPosition && canShow.bottom ? 'center'
+		: isCenterPosition && canShow.top ? ['top', 'center']
+			: Array.isArray(parentPositions) ? [parentPositions[0] === 'bottom' ? 'top' : 'bottom', ...parentPositions.slice(1)]
+				: parentPositions;
+
+	return bestPosition || position;
 }

--- a/package/src/scripts/methods/createMonths.ts
+++ b/package/src/scripts/methods/createMonths.ts
@@ -5,7 +5,7 @@ import visibilityTitle from '@scripts/methods/visibilityTitle';
 const relationshipID = (self: VanillaCalendar) => {
 	if (self.type !== 'multiple') return 0;
 	const columnEls: NodeListOf<HTMLElement> = self.HTMLElement.querySelectorAll(`.${self.CSSClasses.column}`);
-	const indexColumn = [...columnEls].findIndex((column) => column.classList.contains(`${self.CSSClasses.columnMonth}`));
+	const indexColumn = Array.from(columnEls).findIndex((column) => column.classList.contains(`${self.CSSClasses.columnMonth}`));
 	return indexColumn > 0 ? indexColumn : 0;
 };
 

--- a/package/types.ts
+++ b/package/types.ts
@@ -5,6 +5,13 @@ type MM = LeadingZero | 10 | 11 | 12;
 type DD = LeadingZero | `${1 | 2}${0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}` | 30 | 31;
 export type FormatDateString = `${number}-${MM}-${DD}`;
 
+export interface HtmlElementPosition {
+	top: number;
+	bottom: number;
+	left: number;
+	right: number;
+}
+
 export type TypesCalendar = 'default' | 'multiple' | 'month' | 'year';
 
 export type CSSClasses = typeof classes;
@@ -48,15 +55,24 @@ export interface ISelected {
 export type ToggleSelected = boolean | ((self: IVanillaCalendar) => boolean);
 
 export interface IVisibility {
+	/** This parameter determines the theme of the calendar. By default, the theme is determined by the user's system or website settings. */
 	theme: 'light' | 'dark' | 'system';
+	/** To automatically detect and apply the website's theme to the calendar, you can pass a string value as a CSS selector. */
 	themeDetect: string | false;
+	/** This parameter allows you to use abbreviated month names when selecting a month. */
 	monthShort: boolean;
+	/** With this parameter, you can decide whether to display week numbers in the calendar. */
 	weekNumbers: boolean;
+	/** This parameter allows you to highlight weekends in the calendar. */
 	weekend: boolean;
+	/** With this parameter, you can highlight the current day in the calendar. */
 	today: boolean;
+	/** This parameter determines whether all days, including disabled days, will be displayed. */
 	disabled: boolean;
+	/** With this parameter, you can decide whether to display days from the previous and next months. */
 	daysOutside: boolean;
-	positionToInput: 'left' | 'center' | 'right' | ['bottom', 'left'] | ['bottom', 'center'] | ['bottom', 'right'] | ['top', 'left'] | ['top', 'center'] | ['top', 'right'];
+	/** This parameter specifies the position of the calendar relative to input, if the calendar is initialized with the `input` parameter. */
+	positionToInput: 'auto' | 'center' | 'left' | 'right' | ['bottom' | 'top', 'center' | 'left' | 'right'];
 }
 
 export interface ISettings {

--- a/package/types.ts
+++ b/package/types.ts
@@ -5,6 +5,8 @@ type MM = LeadingZero | 10 | 11 | 12;
 type DD = LeadingZero | `${1 | 2}${0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}` | 30 | 31;
 export type FormatDateString = `${number}-${MM}-${DD}`;
 
+export type Positions = 'bottom' | 'top' | 'center' | 'left' | 'right';
+
 export interface HtmlElementPosition {
 	top: number;
 	bottom: number;


### PR DESCRIPTION
- the `auto` will calculate available space on all sides and will always try to position itself to the bottom but when there's not enough space, it will then use the other best position
- also note that the way it works is that after calculating the available spaces, it will then use the code already exists for `positionToInput`, for example the new function `getAvailablePosition()` will return an object with something like the following:

```ts
{
  canShow: {top: true, bottom: true, left: false, right: true}
  parentPositions: ['top', 'left']
}
```
We can see that the `parentPosition` is something that we can then provide to the `positionToInput` because it uses the same structure. 

Below are a couple of animated gifs of the auto-positioning depending on available space

![brave_Cho3EM7Ioz](https://github.com/user-attachments/assets/201fd13b-8085-4939-97e7-3aaab2fefbeb)

![brave_ntV0cmTfxN](https://github.com/user-attachments/assets/41136ec0-a1e3-4884-81f3-1a9bd09e4ed5)
