### PR TITLE
fix: make sure to create picker before calling update(), fixes #274

### DIFF
--- a/demo/pages/input/index.html
+++ b/demo/pages/input/index.html
@@ -12,7 +12,7 @@
 	<body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
 		<h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar</h1>
 		<p class="text-lg mb-12 dark:text-slate-400">A pure JavaScript date and time picker using TypeScript so it supports any JS framework and library.</p>
-		<button id="set-date" type="button" class="mb-7 w-64 border-gray-200 border-2">Set Date</button>
+		<button id="set-date" type="button" class="mb-7 w-64 border-gray-200 border-2">Dynamically Set Date</button>
 		<label>
 			<div>Datepicker tag 'input'</div>
 			<input id="calendar-input" class="input" name="calendar" type="text" readonly />

--- a/demo/pages/input/index.html
+++ b/demo/pages/input/index.html
@@ -12,6 +12,7 @@
 	<body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
 		<h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar</h1>
 		<p class="text-lg mb-12 dark:text-slate-400">A pure JavaScript date and time picker using TypeScript so it supports any JS framework and library.</p>
+		<button id="set-date" type="button" class="mb-7 w-64 border-gray-200 border-2">Set Date</button>
 		<label>
 			<div>Datepicker tag 'input'</div>
 			<input id="calendar-input" class="input" name="calendar" type="text" readonly />

--- a/demo/pages/input/main.ts
+++ b/demo/pages/input/main.ts
@@ -47,4 +47,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	const calendarDiv = new VanillaCalendar('#calendar-div', configDiv);
 	calendarDiv.init();
+
+	document.querySelector('#set-date')?.addEventListener('click', () => {
+		calendarInput.settings.selected = {
+			dates: ['2023-04-07'],
+			month: 3,
+			year: 2023,
+		};
+		calendarInput.update({
+			dates: true,
+			month: true,
+			year: true,
+		});
+		calendarInput.HTMLInputElement!.value = '2023-04-07';
+	});
 });

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -52,6 +52,7 @@ declare class VanillaCalendar implements T.IVanillaCalendar {
 	readonly dateMin: Date;
 	readonly dateMax: Date;
 	readonly isInit: boolean;
+	readonly isInputInit: boolean;
 }
 
 export = VanillaCalendar;

--- a/package/src/scripts/default.ts
+++ b/package/src/scripts/default.ts
@@ -7,6 +7,7 @@ import DOMYear from '@scripts/templates/DOMYear';
 
 export default class DefaultOptionsCalendar {
 	isInit = false;
+	isInputInit = false;
 	input = false;
 	type: T.TypesCalendar = 'default';
 	months = 2;

--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -1,70 +1,10 @@
 import VanillaCalendar from '@src/vanilla-calendar';
-import handleClick from '@scripts/handles/handleClick';
-import reset from '@scripts/reset';
-import { findBestPickerPosition, getOffset } from '@scripts/helpers/position';
-import { IVisibility, CSSClasses } from '@/package/types';
-
-const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
-	if (input) {
-		const pos = position === 'auto'
-			? findBestPickerPosition(input, calendar)
-			: position;
-
-		const getPosition = {
-			top: -calendar.offsetHeight,
-			bottom: input.offsetHeight,
-			left: 0,
-			center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
-			right: input.offsetWidth - calendar.offsetWidth,
-		};
-
-		const YPosition = !Array.isArray(pos) ? 'bottom' : pos[0];
-		const XPosition = !Array.isArray(pos) ? pos : pos[1];
-
-		// add CSS class to extra margin but make sure to only keep 1 class and remove previous one
-		if (YPosition === 'bottom') {
-			calendar.classList.remove(css.calendarToInputTop);
-			calendar.classList.add(css.calendarToInputBottom);
-		} else {
-			calendar.classList.remove(css.calendarToInputBottom);
-			calendar.classList.add(css.calendarToInputTop);
-		}
-
-		const { top: offsetTop, left: offsetLeft } = getOffset(input);
-		const top = offsetTop + getPosition[YPosition];
-		const left = offsetLeft + getPosition[XPosition];
-
-		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
-	}
-};
+import createCalendarToInput from '@scripts/helpers/createCalendarToInput';
+import { setPositionCalendar } from '@scripts/helpers/position';
 
 const handleInput = (self: VanillaCalendar) => {
-	let firstInit = true;
 	const cleanup: Array<() => void> = [];
 	self.HTMLInputElement = self.HTMLElement as HTMLInputElement;
-
-	const createCalendarToInput = () => {
-		const calendar = document.createElement('div');
-		calendar.className = `${self.CSSClasses.calendar} ${self.CSSClasses.calendarToInput} ${self.CSSClasses.calendarHidden}`;
-		self.HTMLElement = calendar;
-		document.body.appendChild(self.HTMLElement);
-		firstInit = false;
-
-		// because of a positioning delay, it might flicker for a short period
-		// we can hide the picker, reposition it, and finally show it back to avoid flickering because of the positioning delay below
-		self.HTMLElement.style.visibility = 'hidden';
-
-		setTimeout(() => {
-			setPositionCalendar(self.HTMLInputElement, calendar, self.settings.visibility.positionToInput, self.CSSClasses);
-			self.HTMLElement.style.visibility = 'visible';
-			self.show();
-		}, 0);
-		reset(self, {
-			year: true, month: true, dates: true, holidays: true, time: true,
-		});
-		if (self.actions.initCalendar) self.actions.initCalendar(self);
-		return handleClick(self);
-	};
 
 	const handleResize = () => setPositionCalendar(self.HTMLInputElement, self.HTMLElement, self.settings.visibility.positionToInput, self.CSSClasses);
 
@@ -82,10 +22,11 @@ const handleInput = (self: VanillaCalendar) => {
 	};
 
 	const handleOpenCalendar = () => {
-		if (firstInit) {
-			cleanup.push(createCalendarToInput());
+		if (!self.isInputInit) {
+			cleanup.push(createCalendarToInput(self));
 		} else {
 			setPositionCalendar(self.HTMLInputElement, self.HTMLElement, self.settings.visibility.positionToInput, self.CSSClasses);
+			self.HTMLElement.style.visibility = 'visible';
 			self.show();
 		}
 		window.addEventListener('resize', handleResize);

--- a/package/src/scripts/helpers/createCalendarToInput.ts
+++ b/package/src/scripts/helpers/createCalendarToInput.ts
@@ -1,0 +1,31 @@
+import VanillaCalendar from '@src/vanilla-calendar';
+import handleClick from '@scripts/handles/handleClick';
+import { setPositionCalendar } from '@scripts/helpers/position';
+import reset from '@scripts/reset';
+
+const createCalendarToInput = (self: VanillaCalendar, isVisible = true) => {
+	self.isInputInit = true;
+	const calendar = document.createElement('div');
+	calendar.className = `${self.CSSClasses.calendar} ${self.CSSClasses.calendarToInput} ${self.CSSClasses.calendarHidden}`;
+	self.HTMLElement = calendar;
+	document.body.appendChild(self.HTMLElement);
+
+	// because of a positioning delay, it might flicker for a short period
+	// we can hide the picker, reposition it, and finally show it back to avoid flickering because of the positioning delay below
+	self.HTMLElement.style.visibility = 'hidden';
+
+	if (isVisible) {
+		queueMicrotask(() => {
+			setPositionCalendar(self.HTMLInputElement, calendar, self.settings.visibility.positionToInput, self.CSSClasses);
+			self.HTMLElement.style.visibility = 'visible';
+			self.show();
+		});
+	}
+	reset(self, {
+		year: true, month: true, dates: true, holidays: true, time: true,
+	});
+	if (self.actions.initCalendar) self.actions.initCalendar(self);
+	return handleClick(self);
+};
+
+export default createCalendarToInput;

--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -135,6 +135,7 @@ export function findBestPickerPosition(input: HTMLInputElement, calendar: HTMLEl
 	return bestPosition || position;
 }
 
+/** Set the calendar picker position according to the user's choice coming from `positionToInput` option. */
 export const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
 	if (input) {
 		const pos = position === 'auto'

--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -1,4 +1,4 @@
-import { HtmlElementPosition, Positions } from '@package/types';
+import { CSSClasses, HtmlElementPosition, IVisibility, Positions } from '@package/types';
 
 /**
  * Get the offset position of an HTML element relative to the viewport.
@@ -134,3 +134,37 @@ export function findBestPickerPosition(input: HTMLInputElement, calendar: HTMLEl
 
 	return bestPosition || position;
 }
+
+export const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
+	if (input) {
+		const pos = position === 'auto'
+			? findBestPickerPosition(input, calendar)
+			: position;
+
+		const getPosition = {
+			top: -calendar.offsetHeight,
+			bottom: input.offsetHeight,
+			left: 0,
+			center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
+			right: input.offsetWidth - calendar.offsetWidth,
+		};
+
+		const YPosition = !Array.isArray(pos) ? 'bottom' : pos[0];
+		const XPosition = !Array.isArray(pos) ? pos : pos[1];
+
+		// add CSS class to extra margin but make sure to only keep 1 class and remove previous one
+		if (YPosition === 'bottom') {
+			calendar.classList.remove(css.calendarToInputTop);
+			calendar.classList.add(css.calendarToInputBottom);
+		} else {
+			calendar.classList.remove(css.calendarToInputBottom);
+			calendar.classList.add(css.calendarToInputTop);
+		}
+
+		const { top: offsetTop, left: offsetLeft } = getOffset(input);
+		const top = offsetTop + getPosition[YPosition];
+		const left = offsetLeft + getPosition[XPosition];
+
+		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
+	}
+};

--- a/package/src/scripts/update.ts
+++ b/package/src/scripts/update.ts
@@ -1,5 +1,6 @@
 import { IReset } from '@package/types';
 import VanillaCalendar from '@src/vanilla-calendar';
+import createCalendarToInput from '@scripts/helpers/createCalendarToInput';
 import messages from '@scripts/helpers/getMessages';
 import reset from '@scripts/reset';
 
@@ -12,6 +13,9 @@ const update = (self: VanillaCalendar, {
 }: IReset = {}) => {
 	if (!self.isInit) throw new Error(messages.notInit);
 
+	if (self.input && !self.isInputInit) {
+		createCalendarToInput(self, false);
+	}
 	reset(self, {
 		year,
 		month,

--- a/package/types.ts
+++ b/package/types.ts
@@ -223,4 +223,5 @@ export interface IVanillaCalendar {
 	readonly dateMin: Date;
 	readonly dateMax: Date;
 	readonly isInit: boolean;
+	readonly isInputInit: boolean;
 }


### PR DESCRIPTION
fixes #274 

- the fix is basically to make sure that the picker element is created **before** the `.update()` does its execution, if the picker element is not yet created then it will be created and then the update runs its execution.
- the code changes are mainly the following
  1. move the `setPositionCalendar` function from `handleInput.ts` into `position.ts` so it could be reused by other files
  2. move the `createCalendarToInput` function from `handleInput.ts` into a new file named `createCalendarToInput.ts` so it could be reused by other files
  3. then the script `update.ts` can now call `createCalendarToInput` to create the picker if it wasn't yet created

for more info about the bug, visit issue #274, the animated gif below simply shows that the input element is no longer being transformed after calling the `.update()`. Prior to this fix, calling the update, before opening the picker, would have reassigned and transformed the input element to include new picker element which was wrong, the input should never be changed and remain untouched

![brave_TNpiLAXhDD](https://github.com/user-attachments/assets/f60b515f-5094-4c11-b4dc-1ed9cc0ae288)
