### PR TITLE
feat: change weekend days, fixes #283

### DIFF
--- a/demo/pages/input/main.ts
+++ b/demo/pages/input/main.ts
@@ -8,6 +8,9 @@ import '@src/styles/vanilla-calendar.css';
 
 const configInput: IOptions = {
 	input: true,
+	date: {
+		weekends: [5, 6]
+	},
 	actions: {
 		changeToInput(e, self) {
 			if (!self.selectedDates || !self.HTMLInputElement) return;
@@ -20,6 +23,7 @@ const configInput: IOptions = {
 		},
 	},
 	settings: {
+		iso8601: false,
 		visibility: {
 			positionToInput: 'center',
 		},

--- a/package/src/scripts/methods/createDays.ts
+++ b/package/src/scripts/methods/createDays.ts
@@ -41,7 +41,7 @@ const setDayModifier = (
 	}
 
 	// if weekend
-	if (self.settings.visibility.weekend && (dayWeekID === 0 || dayWeekID === 6)) {
+	if (self.settings.visibility.weekend && (self.date.weekends || [0, 6]).includes(dayWeekID)) {
 		dayBtnEl.classList.add(self.CSSClasses.dayBtnWeekend);
 	}
 

--- a/package/src/scripts/methods/createWeek.ts
+++ b/package/src/scripts/methods/createWeek.ts
@@ -8,12 +8,18 @@ const createWeekDays = (self: VanillaCalendar, weekEl: HTMLElement, weekday: str
 		const weekDayName = weekday[i];
 		const weekDayEl = templateWeekDayEl.cloneNode(true) as HTMLElement;
 		weekDayEl.className = `${self.CSSClasses.weekDay}`;
-		weekDayEl.className = `${self.CSSClasses.weekDay}${self.settings.visibility.weekend && self.settings.iso8601
-			? (i === 5 || i === 6
-				? ` ${self.CSSClasses.weekDayWeekend}` : '')
-			: self.settings.visibility.weekend && !self.settings.iso8601
-				? (i === 0 || i === 6 ? ` ${self.CSSClasses.weekDayWeekend}` : '')
+		if (self.date.weekends) {
+			weekDayEl.className = `${self.CSSClasses.weekDay}${self.settings.visibility.weekend
+				? (self.date.weekends?.includes(i) ? ` ${self.CSSClasses.weekDayWeekend}` : '')
 				: ''}`;
+		} else {
+			weekDayEl.className = `${self.CSSClasses.weekDay}${self.settings.visibility.weekend && self.settings.iso8601
+				? (i === 5 || i === 6
+					? ` ${self.CSSClasses.weekDayWeekend}` : '')
+				: self.settings.visibility.weekend && !self.settings.iso8601
+					? (i === 0 || i === 6 ? ` ${self.CSSClasses.weekDayWeekend}` : '')
+					: ''}`;
+		}
 		weekDayEl.innerText = `${weekDayName}`;
 		weekEl.appendChild(weekDayEl);
 	}

--- a/package/types.ts
+++ b/package/types.ts
@@ -22,6 +22,7 @@ export interface IDates {
 	min: FormatDateString;
 	max: FormatDateString;
 	today: Date;
+	weekends?: number[];
 }
 
 export interface IRange {


### PR DESCRIPTION
setting to allow changing weekend days, for example Friday/Saturday instead of Saturday/Sunday as per Discussion #283 

![image](https://github.com/user-attachments/assets/af3c7528-3fd7-4ec4-b922-624bfd94d88a)


However, it's currently broken when enabling `iso8601: true`, that would have to be fixed but I don't have more time to look into this. There's also probably a lot more code that calculate days/weekends somewhere else, so it's quite possible that I didn't cover everything. I assume that the `iso8601` could probably be ignored **but** we would probably also need another setting to know which day is the starting (for example start on Sunday or Monday or even Tuesday)

![image](https://github.com/user-attachments/assets/6965acdb-0358-414f-8867-0f517c2df249)
