### PR TITLE
feat: add new `changeSetting()` function

### DIFF
--- a/demo/pages/input/main.ts
+++ b/demo/pages/input/main.ts
@@ -80,11 +80,11 @@ document.addEventListener('DOMContentLoaded', () => {
 	calendarDiv.init();
 
 	document.querySelector('#set-date')?.addEventListener('click', () => {
-		calendarInput.settings.selected = {
+		calendarInput.changeSetting('selected', {
 			dates: ['2023-04-07'],
 			month: 3,
 			year: 2023,
-		};
+		});
 		calendarInput.update({
 			dates: true,
 			month: true,

--- a/docs/en/reference/main/initialize-and-update.mdx
+++ b/docs/en/reference/main/initialize-and-update.mdx
@@ -64,3 +64,18 @@ The `hide()` method allows you to hide the calendar if it has been shown.
 ```js
 calendar.hide();
 ```
+
+## changeSetting()
+
+The `changeSetting()` method allows you to change a single setting.
+The first argument is the name of the setting you want to change and the second argument is the value.
+
+```js
+calendar.changeSetting('range', { min: 'today' });
+```
+
+<Info>
+  Please note that when the value provided is an object, it will be merged with any existing setting object properties.
+	For example if our internal setting is `{ range: { min: '1970-01-01', max: '2099-12-31' }}` and we provide the new setting `{ range: { max: 'today' }}`
+	then the new settings will become `{ range: { min: '1970-01-01', max: 'today' }}`
+</Info>

--- a/package/src/scripts/changeSetting.ts
+++ b/package/src/scripts/changeSetting.ts
@@ -1,0 +1,31 @@
+import type VanillaCalendar from '@src/vanilla-calendar';
+import * as T from '@package/types';
+
+/**
+ * Deep merge two objects.
+ * @param target
+ * @param ...sources
+ */
+export function mergeDeep(target: any, ...sources: any[]): any {
+	const isObject = (item: any) => (item && typeof item === 'object' && !Array.isArray(item));
+
+	if (!sources.length) return target;
+	const source = sources.shift();
+
+	if (isObject(target) && isObject(source)) {
+		Object.keys(source).forEach((key: any) => {
+			if (isObject(source[key])) {
+				if (!target[key]) Object.assign(target, { [key]: {} });
+				mergeDeep(target[key], source[key]);
+			} else {
+				Object.assign(target, { [key]: source[key] });
+			}
+		});
+	}
+
+	return mergeDeep(target, ...sources);
+}
+
+export function changeSetting<S extends keyof T.IPartialSettings, K extends T.IPartialSettings[S]>(self: VanillaCalendar, option: S, value: K) {
+	self.settings = mergeDeep(self.settings, { [option]: value }) as T.ISettings;
+}

--- a/package/src/vanilla-calendar.ts
+++ b/package/src/vanilla-calendar.ts
@@ -5,6 +5,7 @@ import update from '@scripts/update';
 import destroy from '@scripts/destroy';
 import show from '@scripts/show';
 import hide from '@scripts/hide';
+import { changeSetting } from '@scripts/changeSetting';
 import messages from '@scripts/helpers/getMessages';
 
 export default class VanillaCalendar extends DefaultOptionsCalendar implements T.IVanillaCalendar {
@@ -38,4 +39,6 @@ export default class VanillaCalendar extends DefaultOptionsCalendar implements T
 	show = () => show(this);
 
 	hide = () => hide(this);
+
+	changeSetting = <S extends keyof T.IPartialSettings, K extends T.IPartialSettings[S]>(option: S, value: K) => changeSetting(this, option, value);
 }

--- a/package/types.ts
+++ b/package/types.ts
@@ -52,21 +52,37 @@ export interface IRange {
 }
 
 export interface ISelection {
+	/** This parameter determines whether it's allowed to select one or multiple days, or if day selection is completely disabled. */
 	day: false | 'single' | 'multiple' | 'multiple-ranged';
+	/** This parameter allows you to disable the selection of months, allow switching between months only using arrows, or allow switching between months in any way. */
 	month: boolean | 'only-arrows';
+	/** This parameter allows you to disable the selection of years, allow switching between years only using arrows, or allow switching between years in any way. */
 	year: boolean | 'only-arrows';
+	/** This parameter enables time selection. You can also specify the time format using a boolean value or a number: 24-hour or 12-hour format. */
 	time: boolean | 12 | 24;
+	/** This parameter determines how time selection is allowed: `'all'` (any method) or `'range'` (only with the controller). */
 	controlTime: 'all' | 'range';
+	/** This parameter sets the step for the hour controller. You can choose any number from 1 to 23. */
 	stepHours: number;
+	/** This parameter sets the step for the minute controller. You can choose any number from 1 to 59. */
 	stepMinutes: number;
+	/** This option allows you to enable/disable cancellation of the selected date by pressing again. */
 	cancelableDay: boolean;
 }
 
 export interface ISelected {
+	/** This parameter allows you to specify a list of dates that will be selected when the calendar is initialized. */
 	dates?: Array<Date | number | FormatDateString>;
+	/** This parameter determines the month that will be displayed when the calendar is initialized. Months are numbered from 0 to 11. */
 	month?: number;
+	/** This parameter determines the year that will be displayed when the calendar is initialized. */
 	year?: number;
+	/** This parameter allows you to specify dates that will be considered holidays and will receive additional CSS modifiers. */
 	holidays?: Array<Date | number | FormatDateString>;
+	/**
+	 * This parameter allows you to set the time that will be displayed when the calendar is initialized.
+	 * The time is specified in the `'hh:mm aa'` format, where `'aa'` is the AM/PM marker. If using the 24-hour format, the `'aa'` marker is not required.
+	 */
 	time?: string;
 }
 
@@ -94,13 +110,25 @@ export interface IVisibility {
 }
 
 export interface ISettings {
+	/** This parameter sets the language localization of the calendar. */
 	lang: string;
+	/**
+	 * This parameter sets the start of the week in accordance with the international standard ISO 8601.
+	 * If set to `'false'`, the week will start on Sunday; otherwise, it starts on Monday.
+	 */
 	iso8601: boolean;
 	range: IRange;
 	selection: ISelection;
 	selected: ISelected;
 	visibility: IVisibility;
 }
+
+export type IPartialSettings = Partial<Pick<ISettings, 'iso8601' | 'lang'> & {
+	range: Partial<IRange>;
+	selection: Partial<ISelection>;
+	selected: Partial<ISelected>;
+	visibility: Partial<IVisibility>;
+}>;
 
 export interface ILocale {
 	months: string[] | [];
@@ -158,14 +186,7 @@ export interface IOptions {
 	toggleSelected?: ToggleSelected;
 	date?: Partial<IDates>;
 	sanitizer?: (dirtyHtml: string) => unknown;
-	settings?: Partial<{
-		lang: string;
-		iso8601: boolean;
-		range: Partial<IRange>;
-		selection: Partial<ISelection>;
-		selected: Partial<ISelected>;
-		visibility: Partial<IVisibility>;
-	}>;
+	settings?: Partial<IPartialSettings>;
 	locale?: Partial<ILocale>;
 	actions?: Partial<IActions>;
 	popups?: IPopups;
@@ -179,7 +200,7 @@ export interface IVanillaCalendar {
 	months: number;
 	jumpMonths: number;
 	jumpToSelectedDate: boolean;
-	toggleSelected: ToggleSelected
+	toggleSelected: ToggleSelected;
 	date: IDates;
 	settings: {
 		lang: string;


### PR DESCRIPTION
- it's meant to be used to change a single setting at a time, for example `calendar.changeSetting('range', { min: 'today' });`
- this is partially related to #273, I'm not sure if that is what you had in mind to close the issue.
  - also related to 3.0 Roadmap most probably
- we can also see below that the method also has intelliSense and will show the user which value is available depending on the setting name provided

![image](https://github.com/user-attachments/assets/7c222cd3-217f-4384-be91-8860e7f5ca06)

NOTE

I saw your code suggestion 
```ts
function changeSetting(calendar: VanillaCalendar, settings: ISettings) {
  calendar.settings = { ...calendar.settings, ...settings };
}
```
but that might not always be a good approach because setting properties that are objects (like `IRange`, `ISelected`, ...) will be shallow merged. For example if you have 2 calendar instances and you make a change with the function you suggested, then that will change the setting on both instances
```ts
const options1 = { input: true };
const options2 = { input: true };
const calendar1 = new VanillaCalendar('#calendar-div1', options1);
const calendar2 = new VanillaCalendar('#calendar-div2', options2);
calendar1.changeSetting('range', { min: 'today' });

// with shallow copy, options1 will equal options2
```
... so a deep merge is better and also note that the deep merge is also extending any object properties, I gave an example in the docs :)