### PR TITLE
fix: add missing accessibility attributes, fixes #233

### DIFF
--- a/examples/internationalization-assign-manually.ts
+++ b/examples/internationalization-assign-manually.ts
@@ -3,13 +3,14 @@ import { IOptions } from 'vanilla-calendar-pro/types';
 import 'vanilla-calendar-pro/build/vanilla-calendar.min.css';
 
 const options: IOptions = {
-  settings: {
-    lang: 'define',
-  },
-  locale: {
-    months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-    weekday: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-  },
+	settings: {
+		lang: 'define',
+	},
+	locale: {
+		months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+		weekday: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+		longWeekday: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+	},
 };
 
 const calendar = new VanillaCalendar('#calendar', options);

--- a/package/index.d.ts
+++ b/package/index.d.ts
@@ -22,6 +22,7 @@ declare class VanillaCalendar implements T.IVanillaCalendar {
 	actions: T.IActions;
 	sanitizer: (dirtyHtml: string) => unknown;
 	popups: T.IPopups;
+	ariaLabels: T.AriaLabels;
 	CSSClasses: T.CSSClasses;
 	DOMTemplates: T.IDOMTemplates;
 

--- a/package/labels.ts
+++ b/package/labels.ts
@@ -1,0 +1,8 @@
+const labels = {
+	previousMonth: 'previous month',
+	previousYear: 'previous year',
+	nextMonth: 'next month',
+	nextYear: 'next year',
+};
+
+export default labels;

--- a/package/src/scripts/default.ts
+++ b/package/src/scripts/default.ts
@@ -4,6 +4,7 @@ import DOMDefault from '@scripts/templates/DOMDefault';
 import DOMMultiple from '@scripts/templates/DOMMultiple';
 import DOMMonth from '@scripts/templates/DOMMonth';
 import DOMYear from '@scripts/templates/DOMYear';
+import labels from '@/package/labels';
 
 export default class DefaultOptionsCalendar {
 	isInit = false;
@@ -85,6 +86,7 @@ export default class DefaultOptionsCalendar {
 		hideCalendar: null,
 	};
 	popups: T.IPopups = {};
+	ariaLabels: T.AriaLabels = { ...labels };
 	CSSClasses: T.CSSClasses = { ...classes };
 	DOMTemplates: T.IDOMTemplates = {
 		default: DOMDefault(this.CSSClasses),

--- a/package/src/scripts/default.ts
+++ b/package/src/scripts/default.ts
@@ -66,6 +66,7 @@ export default class DefaultOptionsCalendar {
 	locale: T.ILocale = {
 		months: [],
 		weekday: [],
+		longWeekday: [],
 	};
 	sanitizer = (dirtyHtml: string) => dirtyHtml;
 	actions: T.IActions = {

--- a/package/src/scripts/helpers/createComponents.ts
+++ b/package/src/scripts/helpers/createComponents.ts
@@ -1,14 +1,16 @@
 import VanillaCalendar from '@src/vanilla-calendar';
 
-export const ArrowPrev = (self: VanillaCalendar) => (`
+export const ArrowPrev = (self: VanillaCalendar, type = '') => (`
 	<button type="button"
+		aria-label="${self.ariaLabels[type === 'year' ? 'previousYear' : 'previousMonth']}"
 		class="${self.CSSClasses.arrow} ${self.CSSClasses.arrowPrev}"
 		data-calendar-arrow="prev">
 	</button>
 `);
 
-export const ArrowNext = (self: VanillaCalendar) => (`
+export const ArrowNext = (self: VanillaCalendar, type = '') => (`
 	<button type="button"
+		aria-label="${self.ariaLabels[type === 'year' ? 'nextYear' : 'nextMonth']}"
 		class="${self.CSSClasses.arrow} ${self.CSSClasses.arrowNext}"
 		data-calendar-arrow="next">
 	</button>

--- a/package/src/scripts/helpers/getLocale.ts
+++ b/package/src/scripts/helpers/getLocale.ts
@@ -5,7 +5,9 @@ const capitalizeFirstLetter = (str: string) => `${str.charAt(0).toUpperCase()}${
 
 const getLocaleWeekday = (self: VanillaCalendar, i: number) => {
 	const weekday = new Date(`1978-01-0${i + 1}T00:00:00.000Z`).toLocaleString(self.settings.lang, { weekday: 'short', timeZone: 'UTC' });
+	const longWeekday = new Date(`1978-01-0${i + 1}T00:00:00.000Z`).toLocaleString(self.settings.lang, { weekday: 'long', timeZone: 'UTC' });
 	(self.locale.weekday as string[]).push(capitalizeFirstLetter(weekday));
+	(self.locale.longWeekday as string[]).push(capitalizeFirstLetter(longWeekday));
 };
 
 const getLocaleMonth = (self: VanillaCalendar, i: number) => {
@@ -21,6 +23,7 @@ const getLocale = (self: VanillaCalendar) => {
 	}
 
 	self.locale.weekday = [];
+	self.locale.longWeekday = [];
 	self.locale.months = [];
 
 	for (let i = 0; i < 7; i++) getLocaleWeekday(self, i);

--- a/package/src/scripts/helpers/parseComponent.ts
+++ b/package/src/scripts/helpers/parseComponent.ts
@@ -3,8 +3,9 @@ import getComponent from '@scripts/helpers/getComponent';
 
 export const DOMParser = (self: VanillaCalendar, template: string) => (
 	template.replace(/[\n\t]/g, '').replace(/<#(?!\/?Multiple)(.*?)>/g, (_, p1) => {
-		const component = getComponent(p1.replace(/[/\s\n\t]/g, ''));
-		const html = component ? component(self) : '';
+		const [__, comp, attribute] = /(.*)\s?\[(.*)\].*/g.exec(p1) || [];
+		const component = getComponent((comp || p1).replace(/[/\s\n\t]/g, ''));
+		const html = component ? component(self, attribute) : '';
 		return self.sanitizer(html);
 	})
 ).replace(/[\n\t]/g, '');

--- a/package/src/scripts/methods/createDays.ts
+++ b/package/src/scripts/methods/createDays.ts
@@ -52,6 +52,7 @@ const setDayModifier = (
 
 	// if selected day
 	if (self.selectedDates?.includes(date)) {
+		dayBtnEl.ariaSelected = 'true';
 		dayBtnEl.classList.add(self.CSSClasses.dayBtnSelected);
 		if (self.selectedDates.length > 1 && self.settings.selection.day === 'multiple-ranged') {
 			if (self.selectedDates[0] === date) {
@@ -73,6 +74,7 @@ const setDayModifier = (
 		const nextDate = +new Date(date);
 
 		if (nextDate > firstDate && nextDate < lastDate) {
+			dayBtnEl.ariaSelected = 'true';
 			dayBtnEl.classList.add(self.CSSClasses.dayBtnSelected);
 			dayEl.classList.add(self.CSSClasses.daySelectedIntermediate);
 		}
@@ -93,6 +95,8 @@ const createDay = (
 	dayEl.className = self.CSSClasses.day;
 
 	const dayBtnEl = document.createElement('button');
+	dayBtnEl.ariaLabel = date;
+	dayBtnEl.ariaSelected = 'false';
 	dayBtnEl.className = `${self.CSSClasses.dayBtn}${modifier ? ` ${modifier}` : ''}`;
 	dayBtnEl.type = 'button';
 	dayBtnEl.innerText = String(day);

--- a/package/src/scripts/methods/createMonths.ts
+++ b/package/src/scripts/methods/createMonths.ts
@@ -11,8 +11,11 @@ const relationshipID = (self: VanillaCalendar) => {
 
 const createMonthEl = (self: VanillaCalendar, templateMonthEl: HTMLButtonElement, selectedMonth: number, monthTitle: string, monthDisabled: boolean, i: number) => {
 	const monthEl = templateMonthEl.cloneNode(false) as HTMLButtonElement;
-	monthEl.className = `${self.CSSClasses.monthsMonth}${selectedMonth === i ? ` ${self.CSSClasses.monthsMonthSelected}`
+	const isMonthSelected = selectedMonth === i;
+	monthEl.className = `${self.CSSClasses.monthsMonth}${isMonthSelected ? ` ${self.CSSClasses.monthsMonthSelected}`
 		: monthDisabled ? ` ${self.CSSClasses.monthsMonthDisabled}` : ''}`;
+	monthEl.ariaLabel = monthTitle;
+	monthEl.ariaSelected = String(isMonthSelected);
 	monthEl.title = monthTitle;
 	monthEl.innerText = `${self.settings.visibility.monthShort ? monthTitle.substring(0, 3) : monthTitle}`;
 	monthEl.dataset.calendarMonth = String(i);

--- a/package/src/scripts/methods/createWeek.ts
+++ b/package/src/scripts/methods/createWeek.ts
@@ -1,12 +1,14 @@
 import VanillaCalendar from '@src/vanilla-calendar';
 
-const createWeekDays = (self: VanillaCalendar, weekEl: HTMLElement, weekday: string[]) => {
+const createWeekDays = (self: VanillaCalendar, weekEl: HTMLElement, weekday: string[], longWeekday: string[]) => {
 	const templateWeekDayEl = document.createElement('b');
 	weekEl.textContent = '';
 
 	for (let i = 0; i < weekday.length; i++) {
 		const weekDayName = weekday[i];
+		const longWeekdayName = longWeekday[i];
 		const weekDayEl = templateWeekDayEl.cloneNode(true) as HTMLElement;
+		weekDayEl.ariaLabel = longWeekdayName;
 		weekDayEl.className = `${self.CSSClasses.weekDay}`;
 		weekDayEl.className = `${self.CSSClasses.weekDay}${self.settings.visibility.weekend && self.settings.iso8601
 			? (i === 5 || i === 6
@@ -21,10 +23,12 @@ const createWeekDays = (self: VanillaCalendar, weekEl: HTMLElement, weekday: str
 
 const createWeek = (self: VanillaCalendar) => {
 	const weekday = [...self.locale.weekday];
+	const longWeekday = [...self.locale.longWeekday];
 	if (!weekday[0]) return;
 	if (self.settings.iso8601) weekday.push((weekday.shift() as string));
+	if (self.settings.iso8601) longWeekday.push((longWeekday.shift() as string));
 	const weekEls: NodeListOf<HTMLElement> = self.HTMLElement.querySelectorAll(`.${self.CSSClasses.week}`);
-	weekEls.forEach((weekEl) => createWeekDays(self, weekEl, weekday));
+	weekEls.forEach((weekEl) => createWeekDays(self, weekEl, weekday, longWeekday));
 };
 
 export default createWeek;

--- a/package/src/scripts/methods/createYears.ts
+++ b/package/src/scripts/methods/createYears.ts
@@ -5,8 +5,11 @@ import visibilityTitle from '@scripts/methods/visibilityTitle';
 
 const createYearEl = (self: VanillaCalendar, templateYearEl: HTMLButtonElement, selectedYear: number, yearDisabled: boolean, i: number) => {
 	const yearEl = templateYearEl.cloneNode(false) as HTMLButtonElement;
-	yearEl.className = `${self.CSSClasses.yearsYear}${selectedYear === i ? ` ${self.CSSClasses.yearsYearSelected}`
+	const isYearSelected = selectedYear === i;
+	yearEl.className = `${self.CSSClasses.yearsYear}${isYearSelected ? ` ${self.CSSClasses.yearsYearSelected}`
 		: yearDisabled ? ` ${self.CSSClasses.yearsYearDisabled}` : ''}`;
+	yearEl.ariaLabel = String(i);
+	yearEl.ariaSelected = String(isYearSelected);
 	yearEl.dataset.calendarYear = String(i);
 	yearEl.title = String(i);
 	yearEl.innerText = String(i);

--- a/package/src/scripts/templates/DOMDefault.ts
+++ b/package/src/scripts/templates/DOMDefault.ts
@@ -2,12 +2,12 @@ import { CSSClasses } from '@package/types';
 
 const DOMDefault = (styles: CSSClasses) => (`
 	<div class="${styles.header}">
-		<#ArrowPrev />
+		<#ArrowPrev [month] />
 		<div class="${styles.headerContent}">
 			<#Month />
 			<#Year />
 		</div>
-		<#ArrowNext />
+		<#ArrowNext [month] />
 	</div>
 	<div class="${styles.wrapper}">
 		<#WeekNumbers />

--- a/package/src/scripts/templates/DOMMultiple.ts
+++ b/package/src/scripts/templates/DOMMultiple.ts
@@ -2,16 +2,16 @@ import { CSSClasses } from '@package/types';
 
 const DOMMultiple = (styles: CSSClasses) => (`
 	<div class="${styles.controls}">
-		<#ArrowPrev />
-		<#ArrowNext />
+		<#ArrowPrev [month] />
+		<#ArrowNext [month] />
 	</div>
 	<div class="${styles.grid}">
 		<#Multiple>
 			<div class="${styles.column}">
 				<div class="${styles.header}">
 					<div class="${styles.headerContent}">
-						<#Month />
-						<#Year />
+						<#Month [month] />
+						<#Year [month] />
 					</div>
 				</div>
 				<div class="${styles.wrapper}">

--- a/package/src/scripts/templates/DOMMultiple.ts
+++ b/package/src/scripts/templates/DOMMultiple.ts
@@ -10,8 +10,8 @@ const DOMMultiple = (styles: CSSClasses) => (`
 			<div class="${styles.column}">
 				<div class="${styles.header}">
 					<div class="${styles.headerContent}">
-						<#Month [month] />
-						<#Year [month] />
+						<#Month />
+						<#Year />
 					</div>
 				</div>
 				<div class="${styles.wrapper}">

--- a/package/src/scripts/templates/DOMYear.ts
+++ b/package/src/scripts/templates/DOMYear.ts
@@ -2,12 +2,12 @@ import { CSSClasses } from '@package/types';
 
 const DOMYears = (styles: CSSClasses) => (`
 	<div class="${styles.header}">
-		<#ArrowPrev />
+		<#ArrowPrev [year] />
 		<div class="${styles.headerContent}">
 			<#Month />
 			<#Year />
 		</div>
-		<#ArrowNext />
+		<#ArrowNext [year] />
 	</div>
 	<div class="${styles.wrapper}">
 		<div class="${styles.content}">

--- a/package/types.ts
+++ b/package/types.ts
@@ -1,4 +1,5 @@
 import classes from './classes';
+import labels from './labels';
 
 type LeadingZero = `${0}${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`;
 type MM = LeadingZero | 10 | 11 | 12;
@@ -17,6 +18,7 @@ export interface HtmlElementPosition {
 export type TypesCalendar = 'default' | 'multiple' | 'month' | 'year';
 
 export type CSSClasses = typeof classes;
+export type AriaLabels = typeof labels;
 
 export interface IDates {
 	min: FormatDateString | 'today';
@@ -105,6 +107,7 @@ export interface ISettings {
 export interface ILocale {
 	months: string[] | [];
 	weekday: string[] | [];
+	longWeekday: string[] | [];
 }
 
 export interface IActions {
@@ -169,6 +172,7 @@ export interface IOptions {
 	locale?: Partial<ILocale>;
 	actions?: Partial<IActions>;
 	popups?: IPopups;
+	ariaLabels?: Partial<AriaLabels>;
 	CSSClasses?: Partial<CSSClasses>;
 	DOMTemplates?: Partial<IDOMTemplates>;
 }
@@ -193,6 +197,7 @@ export interface IVanillaCalendar {
 	actions: IActions;
 	sanitizer: (dirtyHtml: string) => unknown;
 	popups: IPopups;
+	ariaLabels: AriaLabels;
 	CSSClasses: CSSClasses;
 	DOMTemplates: IDOMTemplates;
 


### PR DESCRIPTION
fixes #233 
- add `aria-label` to a few elements
  - days (I had to add the `"long"` read of weekday from locale, perhaps we could use it for short too with a substring of 3 chars?)
  - months
  - years
  - arrows previous/next for both year/month (I went with a regex pattern to read an extra attribute to component as in `<#ArrowPrev [year] />` which `year` is the optional attribute which is then used to read `self.ariaLabels.nextMonth`)
- add `aria-selected` to all dates and also month and/or year picker

I think that this should be enough to make the picker more accessible and close the associated issue :)