### PR TITLE
Fix: set minimum width for the calendar 300

### DIFF
--- a/package/src/scripts/default.ts
+++ b/package/src/scripts/default.ts
@@ -14,6 +14,7 @@ export default class DefaultOptionsCalendar {
 	jumpMonths = 1;
 	jumpToSelectedDate = false;
 	toggleSelected: T.ToggleSelected = true;
+	minimumWidth = 300;
 	date: T.IDates = {
 		min: '1970-01-01',
 		max: '2470-12-31',

--- a/package/src/scripts/helpers/createCalendarToInput.ts
+++ b/package/src/scripts/helpers/createCalendarToInput.ts
@@ -16,7 +16,7 @@ const createCalendarToInput = (self: VanillaCalendar, isVisible = true) => {
 
 	if (isVisible) {
 		queueMicrotask(() => {
-			setPositionCalendar(self.HTMLInputElement, calendar, self.settings.visibility.positionToInput, self.CSSClasses);
+			setPositionCalendar(self.HTMLInputElement, calendar, self.settings.visibility.positionToInput, self.CSSClasses, self.minimumWidth);
 			self.HTMLElement.style.visibility = 'visible';
 			self.show();
 		});

--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -138,7 +138,7 @@ export function findBestPickerPosition(input: HTMLInputElement, calendar: HTMLEl
 }
 
 /** Set the calendar picker position according to the user's choice coming from `positionToInput` option. */
-export const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
+export const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses, minimumWidth: number) => {
 	if (input) {
 		const pos = position === 'auto'
 			? findBestPickerPosition(input, calendar)
@@ -171,9 +171,11 @@ export const setPositionCalendar = (input: HTMLInputElement | undefined, calenda
 		// make sure the new position is not outside the viewport,
 		// if so then change position to have enough space to show full picker
 		const { vw } = getViewportDimensions();
-		if (left + calendar.clientWidth > vw) {
+		const calendarWidth = calendar.clientWidth === 0 ? minimumWidth : calendar.clientWidth
+
+		if (left + calendarWidth > vw) {
 			const scrollbarWidth = (window.innerWidth - document.body.clientWidth);
-			left = vw - calendar.clientWidth - scrollbarWidth;
+			left = vw - calendarWidth - scrollbarWidth;
 		} else if (left < 0) {
 			left = 0;
 		}


### PR DESCRIPTION
**What**
Add 300 as minimum value for the width in the calendar div

**Why**
`calendar.clientWidth` was returning `0`