### PR TITLE
Enable hover and selected data properties when enableEdgeDatesOnly is set to true

### DIFF
--- a/package/src/scripts/creators/createDates/setDateModifier.ts
+++ b/package/src/scripts/creators/createDates/setDateModifier.ts
@@ -58,12 +58,7 @@ const setDateModifier = (
   }
 
   // When using multiple-ranged with range edges only (only includes start/end selected dates)
-  if (
-    !self.context.disableDates.includes(dateStr) &&
-    self.enableEdgeDatesOnly &&
-    self.context.selectedDates.length > 1 &&
-    self.selectionDatesMode === 'multiple-ranged'
-  ) {
+  if (self.enableEdgeDatesOnly && self.context.selectedDates.length > 1 && self.selectionDatesMode === 'multiple-ranged') {
     const firstDate = getDate(self.context.selectedDates[0]);
     const lastDate = getDate(self.context.selectedDates[self.context.selectedDates.length - 1]);
     const currentDate = getDate(dateStr);

--- a/package/src/scripts/handles/handleSelectDateRange/toggleHoverEffect.ts
+++ b/package/src/scripts/handles/handleSelectDateRange/toggleHoverEffect.ts
@@ -5,7 +5,7 @@ export const addHoverEffect = (date: Date, firstDateEl: HTMLElement | null, last
   if (!state.self?.context?.selectedDates[0]) return;
 
   const formattedDate = getDateString(date);
-  if (state.self.context.disableDates?.includes(formattedDate)) return;
+  if (state.self.context.disableDates?.includes(formattedDate) && state.self.enableEdgeDatesOnly === false) return;
 
   state.self.context.mainElement.querySelectorAll<HTMLElement>(`[data-vc-date="${formattedDate}"]`).forEach((d) => (d.dataset.vcDateHover = ''));
   if (firstDateEl) firstDateEl.dataset.vcDateHoverFirst = '';

--- a/package/src/styles/layout.css
+++ b/package/src/styles/layout.css
@@ -174,17 +174,28 @@
   @apply rounded-l-lg rounded-r-lg;
 }
 
-[data-vc-date][data-vc-date-selected='middle'] [data-vc-date-btn] {
-  @apply rounded-none;
+[data-vc-date][data-vc-date-selected='middle'] [data-vc-date-btn],
+[data-vc-date][data-vc-date-hover]:not([data-vc-date-selected]):not([data-vc-date-hover-first]):not([data-vc-date-hover-last]) [data-vc-date-btn]
+{
+  @apply !rounded-none;
 }
 
-[data-vc-date][data-vc-date-disabled] + [data-vc-date-selected] [data-vc-date-btn],
-[data-vc-date][data-vc-date-disabled] + [data-vc-date-hover] [data-vc-date-btn] {
+[data-vc-date][data-vc-date-selected='first']:has(+ [data-vc-date][data-vc-date-selected='middle'][data-vc-date-hover]) [data-vc-date-btn] {
+  @apply rounded-r-none rounded-l-lg;
+}
+
+[data-vc-date][data-vc-date-selected='middle'][data-vc-date-hover] + [data-vc-date][data-vc-date-selected='last'] [data-vc-date-btn],
+{
+  @apply rounded-l-none rounded-r-lg;
+}
+
+[data-vc-date][data-vc-date-disabled]:not([data-vc-date-selected='middle']) + [data-vc-date-selected] [data-vc-date-btn],
+[data-vc-date][data-vc-date-disabled]:not([data-vc-date-selected='middle']):not([data-vc-date-hover]) + [data-vc-date-hover] [data-vc-date-btn] {
   @apply rounded-l-lg;
 }
 
-[data-vc-date][data-vc-date-hover]:has(+ [data-vc-date-disabled]) [data-vc-date-btn],
-[data-vc-date][data-vc-date-selected]:has(+ [data-vc-date-disabled]) [data-vc-date-btn] {
+[data-vc-date][data-vc-date-hover]:has(+ [data-vc-date-disabled]:not([data-vc-date-selected='middle']):not([data-vc-date-hover])) [data-vc-date-btn],
+[data-vc-date][data-vc-date-selected]:has(+ [data-vc-date-disabled]:not([data-vc-date-selected='middle']):not([data-vc-date-hover])) [data-vc-date-btn] {
   @apply rounded-r-lg;
 }
 

--- a/package/src/styles/layout.css
+++ b/package/src/styles/layout.css
@@ -175,8 +175,7 @@
 }
 
 [data-vc-date][data-vc-date-selected='middle'] [data-vc-date-btn],
-[data-vc-date][data-vc-date-hover]:not([data-vc-date-selected]):not([data-vc-date-hover-first]):not([data-vc-date-hover-last]) [data-vc-date-btn]
-{
+[data-vc-date][data-vc-date-hover]:not([data-vc-date-selected]):not([data-vc-date-hover-first]):not([data-vc-date-hover-last]) [data-vc-date-btn] {
   @apply !rounded-none;
 }
 
@@ -184,8 +183,7 @@
   @apply rounded-r-none rounded-l-lg;
 }
 
-[data-vc-date][data-vc-date-selected='middle'][data-vc-date-hover] + [data-vc-date][data-vc-date-selected='last'] [data-vc-date-btn],
-{
+[data-vc-date][data-vc-date-selected='middle'][data-vc-date-hover] + [data-vc-date][data-vc-date-selected='last'] [data-vc-date-btn] {
   @apply rounded-l-none rounded-r-lg;
 }
 


### PR DESCRIPTION
This PR attempts to solve #329.

As explained in the issue, when using `multiple-ranged` and some days are disabled (and therefore cannot be selected themselves) when the `enableEdgeDatesOnly` setting is set to true, the user can select a date range that includes all these dates, even though this isn't portrayed in the Calendar.

This PR does the following:

- Tries to uncouple applying the needed data properties to just the disabledDates array, instead it checks for enableEdgeDatesOnly to apply them for both hover and on selection.
- Changes the CSS so that the borders work with the new data properties applied.

I refrained from changing any other CSS (like lower opacity for the disabled dates background) since they can be applied by the user if needed and is quite opinionated.

I understand that maybe a new setting could be a better fix for this, just decided to provide you with my fix in case you decide to apply something like this.

Thank you for your time!