### PR TITLE
fix: use `setTimeout` for cross-compatibility

### DIFF
--- a/package/src/scripts/creators/createToInput.ts
+++ b/package/src/scripts/creators/createToInput.ts
@@ -25,7 +25,7 @@ const createToInput = (self: Calendar) => {
     locale: true,
   });
 
-  queueMicrotask(() => show(self));
+  setTimeout(() => show(self));
 
   if (self.onInit) self.onInit(self);
   handleArrowKeys(self);

--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -8,7 +8,7 @@ const handleInput = (self: Calendar) => {
 
   const handleOpenCalendar = () => {
     if (self.context.inputModeInit) {
-      queueMicrotask(() => show(self));
+      setTimeout(() => show(self));
       return;
     }
     createToInput(self);


### PR DESCRIPTION
- `queueMicrotask` is apparently not supported in Salesforce (which is weird), so for better cross-compatibility using `setTimeout` works in all environments (including Salesforce)
- another option might be to use a function to check if it's available or fallback to `setTimeout` when not available, but I think it's overkill for this project (I did implement this in my own project though, let me know if you would rather have that approach as seen below)
```ts
export function queueMicrotaskOrSetTimeout(callback: () => void): void {
  try {
    queueMicrotask(callback);
  } catch {
    setTimeout(callback, 0);
  }
}
```