### PR TITLE
Add docs cross reference to `enableJumpToSelectedDate`

### DIFF
--- a/docs/en/reference/settings.mdx
+++ b/docs/en/reference/settings.mdx
@@ -644,7 +644,7 @@ new Calendar('#calendar', {
 });
 ```
 
-This parameter defines the month that will be displayed when the calendar is initialized. According to JS standards, months are numbered from 0 to 11.
+This parameter defines the month that will be displayed when the calendar is initialized. According to JS standards, months are numbered from 0 to 11. See [enableJumpToSelectedDate](/docs/reference/settings#enableJumpToSelectedDate) to default to the first selected date.
 
 ---
 
@@ -662,7 +662,7 @@ new Calendar('#calendar', {
 });
 ```
 
-This parameter defines the year that will be displayed when the calendar is initialized.
+This parameter defines the year that will be displayed when the calendar is initialized. See [enableJumpToSelectedDate](/docs/reference/settings#enableJumpToSelectedDate) to default to the first selected date.
 
 ---
 


### PR DESCRIPTION
Improve docs for `selectedMonth` and `selectedYear` with cross references to relevant setting `enableJumpToSelectedDate`