### PR TITLE
Feature/ISSUE-380 Open on focus

### DIFF
--- a/docs/en/reference/settings.mdx
+++ b/docs/en/reference/settings.mdx
@@ -42,6 +42,24 @@ The `inputMode` parameter indicates that the `mainElement`, passed as the first 
 
 ---
 
+## openOnFocus
+
+`Type: Boolean`
+
+`Default: true`
+
+`Options: true | false`
+
+```ts
+new Calendar('#calendar', {
+  openOnFocus: false
+});
+```
+
+This parameter disables the automatic opening of the calendar allowing developers to implement their own focus handler on the input element
+
+---
+
 ## positionToInput
 
 `Type: String`

--- a/docs/ru/reference/settings.mdx
+++ b/docs/ru/reference/settings.mdx
@@ -42,6 +42,25 @@ new Calendar('#calendar', {
 
 ---
 
+## openOnFocus
+
+`Type: Boolean`
+
+`Default: true`
+
+`Options: true | false`
+
+```ts
+new Calendar('#calendar', {
+  openOnFocus: false
+});
+```
+
+// @TODO Russian translation
+This parameter disables the automatic opening of the calendar allowing developers to implement their own focus handler on the input element
+
+---
+
 ## positionToInput
 
 `Type: String`

--- a/package/src/options.ts
+++ b/package/src/options.ts
@@ -24,6 +24,7 @@ import type {
 export default class OptionsCalendar {
   type: TypesCalendar = 'default';
 
+  openOnFocus: boolean = true;
   inputMode: boolean = false;
   positionToInput: PositionToInput = 'left';
 

--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -15,11 +15,17 @@ const handleInput = (self: Calendar) => {
   };
 
   (self.context.inputElement as HTMLInputElement).addEventListener('click', handleOpenCalendar);
-  (self.context.inputElement as HTMLInputElement).addEventListener('focus', handleOpenCalendar);
+
+  if (self.openOnFocus) {
+    (self.context.inputElement as HTMLInputElement).addEventListener('focus', handleOpenCalendar);
+  }
 
   return () => {
     (self.context.inputElement as HTMLInputElement).removeEventListener('click', handleOpenCalendar);
-    (self.context.inputElement as HTMLInputElement).removeEventListener('focus', handleOpenCalendar);
+
+    if (self.openOnFocus) {
+      (self.context.inputElement as HTMLInputElement).removeEventListener('focus', handleOpenCalendar);
+    }
   };
 };
 

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -77,6 +77,7 @@ export type Reset = {
 };
 
 export type ContextVariables = {
+  openOnFocus: boolean;
   isInit: boolean;
   isShowInInputMode: boolean;
   inputModeInit: boolean;


### PR DESCRIPTION
I've added the openOnFocus parameter to the calendar allowing developers using this plugin to implement their own opening logic when the calendar input gets focused.

I haven't added proper documentation for the RU translation since I'm not that familiar with the language.

I'm also planning to test out an event driven version of this functionality that allows for developers to intersect the opening of the input with "onBeforeOpen" function or something similar to that. But for that I'll be making a different branch, 

Initial feature request: [https://github.com/uvarov-frontend/vanilla-calendar-pro/issues/380](https://github.com/uvarov-frontend/vanilla-calendar-pro/issues/380)