### PR TITLE
fix: use local date components instead of UTC ISO string for Date input

### DIFF
--- a/package/src/scripts/utils/parseDates.ts
+++ b/package/src/scripts/utils/parseDates.ts
@@ -6,7 +6,7 @@ const parseDates: (dates: Array<number | string | Date>) => FormatDateString[] =
   dates.reduce((accumulator: FormatDateString[], date) => {
     if (date instanceof Date || typeof date === 'number') {
       const d = date instanceof Date ? date : new Date(date);
-      accumulator.push(d.toISOString().substring(0, 10) as FormatDateString);
+      accumulator.push(getDateString(d));
     } else if (date.match(/^(\d{4}-\d{2}-\d{2})$/g)) {
       accumulator.push(date as FormatDateString);
     } else {


### PR DESCRIPTION
## Problem

`selectedDates` (and other options) accept a `Date` object, but the date shown in the calendar didn't match it — off by one day in timezones east of UTC (e.g. `new Date(2024, 5, 15)` displayed as June 14).

## Root Cause

`parseDates.ts` converted `Date` objects via `date.toISOString().substring(0, 10)`, which converts to **UTC** before formatting. Local midnight in a positive-UTC-offset timezone becomes the previous day in UTC.

## Fix

Reuse the existing `getDateString()` helper, which formats using local date components (`getFullYear`/`getMonth`/`getDate`) instead of UTC.

Fixes #411