### PR TITLE
fix: don't remove original input when destroying calendar before it was ever opened

### DIFF
--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -68,7 +68,15 @@ export class Calendar extends OptionsCalendar {
 
   update = (resetOptions?: Partial<Reset>) => update(this, resetOptions);
 
-  destroy = () => destroy(this);
+  destroy = () => {
+    const staleElement = this.inputMode ? this.context.inputElement : this.context.mainElement;
+    destroy(this);
+    if (staleElement) {
+      for (const [selector, element] of Calendar.memoizedElements) {
+        if (element === staleElement) Calendar.memoizedElements.delete(selector);
+      }
+    }
+  };
 
   show = () => show(this);
 

--- a/package/src/scripts/methods/destroy.ts
+++ b/package/src/scripts/methods/destroy.ts
@@ -6,7 +6,9 @@ const destroy = (self: Calendar) => {
   if (!self.context.isInit) throw new Error(errorMessages.notInit);
 
   if (self.inputMode) {
-    self.context.mainElement.parentElement?.removeChild(self.context.mainElement);
+    if (self.context.mainElement !== self.context.inputElement) {
+      self.context.mainElement.parentElement?.removeChild(self.context.mainElement);
+    }
     self.context.inputElement?.replaceWith?.(self.context.originalElement);
     setContext(self, 'inputElement', undefined);
   } else {


### PR DESCRIPTION
## Problem

Calling `destroy()` on a calendar with `inputMode: true` removes the original `<input>` element from the DOM instead of restoring it.

## Root Cause

In inputMode, `mainElement` and `inputElement` start out as the **same** DOM node (the `<input>` itself). They only diverge once the popup is actually opened (`createToInput` reassigns `mainElement` to the new popup element). If `destroy()` is called before the calendar was ever opened, `mainElement` is still the input — so `destroy.ts` removing `mainElement` from the DOM removes the input itself. The subsequent `replaceWith` call then no-ops on an already-detached node, so the input never gets restored.

## Fix

Only remove `mainElement` from the DOM when it's actually a separate popup element (`mainElement !== inputElement`).

## Bonus fix: stale memoized element cache

While verifying this, found a related issue: `Calendar.memoizedElements` (a static cache keyed by selector string, used so repeated `new Calendar('#same-selector')` calls reuse the same queried element) is never invalidated. After `destroy()` swaps the live element for a clone (`originalElement`), the cache still points at the old, now-detached node. Re-constructing a `Calendar` with the same string selector after `destroy()` would silently bind to that stale, invisible element — no error, just broken behavior.

`destroy()` now also removes the matching entry from `memoizedElements` when it's torn down. This applies to both inputMode and the regular (non-input) destroy path, since both replace the live element with a clone.

Fixes #418