### PR TITLE
fix: correct off-by-one in ISO week number calculation

### DIFF
--- a/cypress/e2e/weekNumbers.cy.ts
+++ b/cypress/e2e/weekNumbers.cy.ts
@@ -1,0 +1,24 @@
+const getRowWeekNumbers = (containerSelector: string) =>
+  cy
+    .get(containerSelector)
+    .find('[data-vc-week-number]')
+    .then(($weeks) => [...$weeks].map((el) => Number(el.dataset.vcWeekNumber)));
+
+describe('Week numbers', () => {
+  it('December 2026 ends on week 53 (2026 is a 53-ISO-week year)', () => {
+    cy.visit('/pages/week-numbers/');
+    getRowWeekNumbers('#calendar-2026').should('deep.equal', [49, 50, 51, 52, 53]);
+    cy.get('#calendar-2026').find('[data-vc-week-number="53"]').should('have.attr', 'data-vc-week-year', '2026');
+  });
+
+  it('December 2025 rolls its last row into week 1 of 2026 (2025 is a 52-ISO-week year)', () => {
+    cy.visit('/pages/week-numbers/');
+    getRowWeekNumbers('#calendar-2025').should('deep.equal', [49, 50, 51, 52, 1]);
+    cy.get('#calendar-2025').find('[data-vc-week-number="1"]').should('have.attr', 'data-vc-week-year', '2026');
+  });
+
+  it('firstWeekday=0 (Sunday-start weeks) still numbers rows sequentially with no gaps or duplicates', () => {
+    cy.visit('/pages/week-numbers/');
+    getRowWeekNumbers('#calendar-sunday-start').should('deep.equal', [22, 23, 24, 25, 26]);
+  });
+});

--- a/demo/pages/week-numbers/index.html
+++ b/demo/pages/week-numbers/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
+    <title>The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript frameworks and libraries.</title>
+    <link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+    <link rel="stylesheet" href="../../../index.css" />
+    <script defer src="./main.ts" type="module"></script>
+  </head>
+  <body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
+    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.</p>
+    <div id="calendar-2026"></div>
+    <div id="calendar-2025"></div>
+    <div id="calendar-sunday-start"></div>
+  </body>
+</html>

--- a/demo/pages/week-numbers/main.ts
+++ b/demo/pages/week-numbers/main.ts
@@ -1,0 +1,37 @@
+import { Calendar, type Options } from '@src/index';
+
+import '@src/styles/index.css';
+
+document.addEventListener('DOMContentLoaded', () => {
+  // 2026 has 53 ISO weeks (Dec 28-30, 2026 fall in week 53)
+  const config2026: Options = {
+    selectedMonth: 11,
+    selectedYear: 2026,
+    enableWeekNumbers: true,
+  };
+
+  // December 2025's last week rolls over into week 1 of 2026 (year-boundary case, control for #402)
+  const config2025: Options = {
+    selectedMonth: 11,
+    selectedYear: 2025,
+    enableWeekNumbers: true,
+  };
+
+  // firstWeekday other than Monday (ISO 8601 has no official rule here) - checks the library's
+  // generalized week numbering stays self-consistent (sequential, no gaps/duplicates)
+  const configSundayStart: Options = {
+    selectedMonth: 5,
+    selectedYear: 2028,
+    firstWeekday: 0,
+    enableWeekNumbers: true,
+  };
+
+  const calendar2026 = new Calendar('#calendar-2026', config2026);
+  calendar2026.init();
+
+  const calendar2025 = new Calendar('#calendar-2025', config2025);
+  calendar2025.init();
+
+  const calendarSundayStart = new Calendar('#calendar-sunday-start', configSundayStart);
+  calendarSundayStart.init();
+});

--- a/package/src/scripts/utils/getWeekNumber.ts
+++ b/package/src/scripts/utils/getWeekNumber.ts
@@ -4,7 +4,7 @@ import type { FormatDateString, WeekDayID } from '@src/index';
 const getWeekNumber = (date: FormatDateString, weekStartDay: WeekDayID) => {
   const currentDate = getDate(date);
   const currentDay = (currentDate.getDay() - weekStartDay + 7) % 7;
-  currentDate.setDate(currentDate.getDate() + 4 - currentDay);
+  currentDate.setDate(currentDate.getDate() + 3 - currentDay);
 
   const yearStart = new Date(currentDate.getFullYear(), 0, 1);
   const weekNumber = Math.ceil(((+currentDate - +yearStart) / 86400000 + 1) / 7);


### PR DESCRIPTION
## Problem

`enableWeekNumbers: true` shows the wrong week numbers around year boundaries — e.g. 2026 (a 53-ISO-week year) only shows up to week 52, with the last week incorrectly bucketed into week 1 of 2027.

## Root Cause

`getWeekNumber.ts` shifts each date to the middle of its week before determining which year's numbering it belongs to (the standard ISO 8601 trick: a week belongs to the year containing its Thursday). The shift was off by one day:

```ts
currentDate.setDate(currentDate.getDate() + 4 - currentDay);
```

`currentDay` is already 0-indexed relative to `weekStartDay` (0 = start of week), so `+4` lands one day past the middle of the week (e.g. Friday instead of Thursday for a Monday-start week). This shifts the year-boundary weeks by one day, which is enough to misattribute the year for the first/last week of the year in specific years.

## Fix

`+4 - currentDay` → `+3 - currentDay`.

Verified against a reference ISO-8601 implementation across 2000–2050 (0 mismatches), and checked self-consistency (sequential numbering, no gaps/duplicates, 52 or 53 weeks/year) for every possible `firstWeekday` (0–6) across 2015–2035, since the library generalizes the "middle of week" trick beyond the ISO-mandated Monday start.

## Tests

Added `cypress/e2e/weekNumbers.cy.ts` with a new `demo/pages/week-numbers` demo page, covering:
- December 2026 (53-week year): row week numbers `[49, 50, 51, 52, 53]`
- December 2025 (52-week year): last row correctly rolls into week 1 of **2026** — the reverse year-boundary case
- June 2028 with `firstWeekday: 0` (Sunday-start): `[22, 23, 24, 25, 26]`, confirming non-Monday starts stay sequential with no gaps/duplicates

Full suite (`default.cy.ts`, `multiple.cy.ts`, `weekNumbers.cy.ts`) passes: 13/13.

Fixes #402