### PR TITLE
fix: apply disableDatesGaps to pre-selected selectedDates on init

### DIFF
--- a/cypress/e2e/disableDatesGaps.cy.ts
+++ b/cypress/e2e/disableDatesGaps.cy.ts
@@ -1,0 +1,24 @@
+describe('disableDatesGaps on initial load (multiple-ranged)', () => {
+  it('clamps displayDateMin/Max around a pre-selected selectedDates entry right after init', () => {
+    cy.visit('/pages/disable-dates-gaps/');
+    // enableDates: '2022-01-10:2022-01-15' and '2022-01-24:2022-01-29', selectedDates: ['2022-01-12']
+    // the gap (2022-01-16..23) should already clamp the selectable range without any click
+    cy.get('[data-vc-date="2022-01-15"]').should('not.have.attr', 'data-vc-date-disabled');
+    cy.get('[data-vc-date="2022-01-16"]').should('have.attr', 'data-vc-date-disabled');
+    cy.get('[data-vc-date="2022-01-29"]').should('have.attr', 'data-vc-date-disabled');
+  });
+
+  it('a forced click past the gap does not extend the selected range', () => {
+    cy.visit('/pages/disable-dates-gaps/');
+    cy.get('[data-vc-date="2022-01-29"]').click({ force: true });
+    cy.get('[data-vc-date-selected]').should('have.length', 1).and('have.attr', 'data-vc-date', '2022-01-12');
+  });
+
+  it('selecting a date within the still-open range works normally', () => {
+    cy.visit('/pages/disable-dates-gaps/');
+    cy.get('[data-vc-date="2022-01-14"]').click();
+    cy.get('[data-vc-date-selected]').should('have.length', 3);
+    cy.get('[data-vc-date="2022-01-12"]').should('have.attr', 'data-vc-date-selected', 'first');
+    cy.get('[data-vc-date="2022-01-14"]').should('have.attr', 'data-vc-date-selected', 'last');
+  });
+});

--- a/demo/pages/disable-dates-gaps/index.html
+++ b/demo/pages/disable-dates-gaps/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
+    <title>The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript frameworks and libraries.</title>
+    <link rel="icon" type="image/svg+xml" href="../../../favicon.svg" />
+    <link rel="stylesheet" href="../../../index.css" />
+    <script defer src="./main.ts" type="module"></script>
+  </head>
+  <body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
+    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">Issue #407 repro. Clicking 2022-01-29 should NOT select past the gap (2022-01-16 to 2022-01-23 are disabled).</p>
+    <div id="calendar"></div>
+  </body>
+</html>

--- a/demo/pages/disable-dates-gaps/main.ts
+++ b/demo/pages/disable-dates-gaps/main.ts
@@ -1,0 +1,19 @@
+import { Calendar, type Options } from '@src/index';
+
+import '@src/styles/index.css';
+
+document.addEventListener('DOMContentLoaded', () => {
+  // reproduction from https://github.com/uvarov-frontend/vanilla-calendar-pro/issues/407
+  const options: Options = {
+    selectionDatesMode: 'multiple-ranged',
+    disableAllDates: true,
+    enableDates: ['2022-01-10:2022-01-15', '2022-01-24:2022-01-29'],
+    selectedDates: ['2022-01-12'],
+    selectedMonth: 0,
+    disableDatesGaps: true,
+    selectedYear: 2022,
+  };
+
+  const calendar = new Calendar('#calendar', options);
+  calendar.init();
+});

--- a/package/src/scripts/creators/createDates/updateDateModifiers.ts
+++ b/package/src/scripts/creators/createDates/updateDateModifiers.ts
@@ -1,0 +1,15 @@
+import setDateModifier from '@scripts/creators/createDates/setDateModifier';
+import getDate from '@scripts/utils/getDate';
+import type { Calendar, FormatDateString, WeekDayID } from '@src/index';
+
+const updateDateModifiers = (self: Calendar) => {
+  const dateEls = self.context.mainElement.querySelectorAll<HTMLElement>('[data-vc-date]');
+  dateEls.forEach((dateEl) => {
+    const dateBtnEl = dateEl.querySelector<HTMLButtonElement>('[data-vc-date-btn]') as HTMLButtonElement;
+    const dateStr = dateEl.dataset.vcDate as FormatDateString;
+    const dayWeekID = getDate(dateStr).getDay() as WeekDayID;
+    setDateModifier(self, self.context.selectedYear, dateEl, dateBtnEl, dayWeekID, dateStr, 'current');
+  });
+};
+
+export default updateDateModifiers;

--- a/package/src/scripts/handles/handleClick/handleClickDate.ts
+++ b/package/src/scripts/handles/handleClick/handleClickDate.ts
@@ -1,19 +1,8 @@
-import setDateModifier from '@scripts/creators/createDates/setDateModifier';
+import updateDateModifiers from '@scripts/creators/createDates/updateDateModifiers';
 import handleMonth from '@scripts/handles/handleMonth';
 import handleSelectDate from '@scripts/handles/handleSelectDate';
 import handleSelectDateRanged from '@scripts/handles/handleSelectDateRange/handleSelectDateRange';
-import getDate from '@scripts/utils/getDate';
-import type { Calendar, FormatDateString, WeekDayID } from '@src/index';
-
-const updateDateModifier = (self: Calendar) => {
-  const dateEls = self.context.mainElement.querySelectorAll<HTMLElement>('[data-vc-date]');
-  dateEls.forEach((dateEl) => {
-    const dateBtnEl = dateEl.querySelector<HTMLButtonElement>('[data-vc-date-btn]') as HTMLButtonElement;
-    const dateStr = dateEl.dataset.vcDate as FormatDateString;
-    const dayWeekID = getDate(dateStr).getDay() as WeekDayID;
-    setDateModifier(self, self.context.selectedYear, dateEl, dateBtnEl, dayWeekID, dateStr, 'current');
-  });
-};
+import type { Calendar } from '@src/index';
 
 const handleClickDate = (self: Calendar, event: MouseEvent) => {
   const element = event.target as HTMLElement;
@@ -37,9 +26,9 @@ const handleClickDate = (self: Calendar, event: MouseEvent) => {
   const dayNextEl = element.closest('[data-vc-date-month="next"]');
 
   const actionMapping = {
-    prev: () => (self.enableMonthChangeOnDayClick ? handleMonth(self, 'prev') : updateDateModifier(self)),
-    next: () => (self.enableMonthChangeOnDayClick ? handleMonth(self, 'next') : updateDateModifier(self)),
-    current: () => updateDateModifier(self),
+    prev: () => (self.enableMonthChangeOnDayClick ? handleMonth(self, 'prev') : updateDateModifiers(self)),
+    next: () => (self.enableMonthChangeOnDayClick ? handleMonth(self, 'next') : updateDateModifiers(self)),
+    current: () => updateDateModifiers(self),
   };
 
   actionMapping[dayPrevEl ? 'prev' : dayNextEl ? 'next' : 'current']();

--- a/package/src/scripts/methods/init.ts
+++ b/package/src/scripts/methods/init.ts
@@ -1,7 +1,9 @@
 import create from '@scripts/creators/create';
+import updateDateModifiers from '@scripts/creators/createDates/updateDateModifiers';
 import handleArrowKeys from '@scripts/handles/handleArrowKeys';
 import handleClick from '@scripts/handles/handleClick/handleClick';
 import handleInput from '@scripts/handles/handleInput';
+import handleSelectDateRange from '@scripts/handles/handleSelectDateRange/handleSelectDateRange';
 import initAllVariables from '@scripts/utils/initVariables/initAllVariables';
 import setContext from '@scripts/utils/setContext';
 import type { Calendar } from '@src/index';
@@ -14,6 +16,10 @@ const init = (self: Calendar) => {
 
   initAllVariables(self);
   create(self);
+  if (self.selectionDatesMode === 'multiple-ranged' && self.context.selectedDates.length === 1) {
+    handleSelectDateRange(self, null);
+    updateDateModifiers(self);
+  }
   if (self.onInit) self.onInit(self);
   handleArrowKeys(self);
   return handleClick(self);


### PR DESCRIPTION
## Problem

`disableDatesGaps` doesn't clamp the selectable range when the range's first date comes from a pre-configured `selectedDates` option — only when it's selected via a click. This lets a range selection jump straight over a disabled gap on the very first interaction after load.

## Root Cause

The clamping (`updateDisabledDates()`, adjusting `displayDateMin`/`displayDateMax` around the selected date) only ran inside the click handler (`handleSelectDateRange`'s `set` branch). Nothing equivalent ran during `init()`.

It couldn't simply run earlier in `initAllVariables`, either: `context.disableDates` is only fully populated day-by-day while the date grid renders (`createDate.ts`), which happens after `initAllVariables` — so the fix has to run after `create()`.

## Fix

- `init.ts`: after `create()`, if `selectionDatesMode === 'multiple-ranged'` and exactly one date is selected, call `handleSelectDateRange(self, null)` — the same call `reset.ts` already makes for `.update()`/`.set()`, just previously missing from the initial `init()` path.
- Extracted the day-button attribute refresh (previously a local helper in `handleClickDate.ts`) into a shared `updateDateModifiers.ts`, and call it after the clamp in `init.ts` so already-rendered day buttons pick up the new disabled state immediately.

## Tests

Added `cypress/e2e/disableDatesGaps.cy.ts` + `demo/pages/disable-dates-gaps`, covering:
- the gap is disabled right after init, no interaction needed
- a forced click past the gap doesn't extend the selection
- selecting a date within the still-open range still works normally

Fixes #407