### PR TITLE
fix(a11y): improve calendar accessibility and demo semantics

### DIFF
--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["html-validate:recommended"],
+  "rules": {
+    "doctype-style": ["error", { "style": "lowercase" }],
+    "void-style": ["error", { "style": "selfclosing" }],
+    "no-inline-style": "off"
+  }
+}

--- a/cypress/e2e/a11y.cy.ts
+++ b/cypress/e2e/a11y.cy.ts
@@ -54,6 +54,14 @@ describe('Accessibility (axe-core)', () => {
     checkA11y('#calendar-bounded');
   });
 
+  it('calendars inside a shadow root have no ARIA violations', () => {
+    cy.visit('/pages/shadow-dom/');
+    // the inputMode popup only exists once the field has been opened
+    cy.get('#widget-4').shadow().find('[data-vc-shadow-input]').click();
+    cy.get('#widget-4').shadow().find('[data-vc="calendar"]').should('not.have.attr', 'data-vc-calendar-hidden');
+    checkA11y();
+  });
+
   it('every option combination carrying its own ARIA markup has no violations', () => {
     cy.visit('/pages/a11y/');
     checkA11y();
@@ -151,6 +159,12 @@ describe('Accessibility (keyboard and focus)', () => {
       const names = [...$inputs].map((input) => (input as HTMLInputElement).name);
       expect(new Set(names).size, 'duplicate form control name').to.eq(names.length);
     });
+  });
+
+  it('states multiselectability only where more than one date can be picked', () => {
+    cy.visit('/pages/a11y/');
+    cy.get('#calendar-ranged [data-vc="content"]').should('have.attr', 'aria-multiselectable', 'true');
+    cy.get('#calendar-popups [data-vc="content"]').should('not.have.attr', 'aria-multiselectable');
   });
 
   it('takes the closed popup out of the focus order and the accessibility tree', () => {

--- a/cypress/e2e/a11y.cy.ts
+++ b/cypress/e2e/a11y.cy.ts
@@ -1,6 +1,7 @@
-// color-contrast and landmark/region are excluded on purpose: they're about the demo page's
-// own styling/structure, not the calendar component's ARIA markup, which is what this checks.
+// color-contrast and the landmark/region rules are excluded on purpose: they are about the demo
+// page's own styling and structure, not the calendar's markup, which is what this checks.
 const axeOptions = {
+  runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa', 'best-practice'] },
   rules: {
     'color-contrast': { enabled: false },
     'landmark-one-main': { enabled: false },
@@ -8,51 +9,177 @@ const axeOptions = {
   },
 };
 
+const checkA11y = (ctx?: string) => {
+  cy.injectAxe();
+  cy.checkA11y(ctx as never, axeOptions as never);
+};
+
 describe('Accessibility (axe-core)', () => {
   it('default calendar view has no ARIA violations', () => {
     cy.visit('/');
-    cy.injectAxe();
-    cy.checkA11y(undefined, axeOptions);
+    checkA11y();
   });
 
   it('month picker view has no ARIA violations', () => {
     cy.visit('/');
     cy.get('.vc-month').click();
-    cy.injectAxe();
-    cy.checkA11y(undefined, axeOptions);
+    checkA11y();
   });
 
   it('year picker view has no ARIA violations', () => {
     cy.visit('/');
     cy.get('.vc-year').click();
-    cy.injectAxe();
-    cy.checkA11y(undefined, axeOptions);
+    checkA11y();
   });
 
   it('type: multiple calendar view has no ARIA violations', () => {
     cy.visit('/pages/multiple/index.html');
-    cy.injectAxe();
-    cy.checkA11y(undefined, axeOptions);
+    checkA11y();
   });
 
   it('type: week calendar view has no ARIA violations', () => {
     cy.visit('/pages/week/');
-    cy.injectAxe();
-    cy.checkA11y('#calendar-week', axeOptions);
+    checkA11y('#calendar-week');
+  });
+
+  it('week numbers have no ARIA violations', () => {
+    cy.visit('/pages/week-numbers/');
+    checkA11y();
   });
 
   it('collapsed calendar view has no ARIA violations', () => {
     cy.visit('/pages/gestures/');
     cy.get('#calendar-bounded [data-vc="collapse"]').click();
     cy.get('#calendar-bounded').should('have.attr', 'data-vc-type', 'week');
-    cy.injectAxe();
-    cy.checkA11y('#calendar-bounded', axeOptions);
+    checkA11y('#calendar-bounded');
   });
 
-  it('inputMode popup has no ARIA violations', () => {
+  it('every option combination carrying its own ARIA markup has no violations', () => {
+    cy.visit('/pages/a11y/');
+    checkA11y();
+  });
+
+  it('inputMode popup has no ARIA violations, open or closed', () => {
     cy.visit('/pages/input/');
     cy.get('#calendar-input').click();
-    cy.injectAxe();
-    cy.checkA11y(undefined, axeOptions);
+    cy.get('[data-vc-input]').should('exist');
+    checkA11y();
+    cy.get('h1').click();
+    cy.get('[data-vc-input]').should('have.attr', 'data-vc-calendar-hidden');
+    checkA11y();
+  });
+});
+
+describe('Accessibility (keyboard and focus)', () => {
+  it('gives every grid a single tab stop', () => {
+    cy.visit('/pages/a11y/');
+    cy.get('#calendar-month [data-vc-months-month][tabindex="0"]').should('have.length', 1);
+    cy.get('#calendar-year [data-vc-years-year][tabindex="0"]').should('have.length', 1);
+    cy.get('#calendar-multiple-week-numbers [data-vc="dates"]').each(($datesEl) => {
+      cy.wrap($datesEl).find('[data-vc-date-btn][tabindex="0"]').should('have.length', 1);
+    });
+  });
+
+  it('anchors that tab stop on the selected date', () => {
+    cy.visit('/pages/a11y/');
+    cy.get('#calendar-ranged [data-vc-date-btn][tabindex="0"]').should('have.attr', 'aria-label', 'April 10, 2023');
+  });
+
+  it('marks the selection on the gridcell, which is the role that supports it', () => {
+    cy.visit('/pages/a11y/');
+    cy.get('#calendar-ranged [data-vc-date="2023-04-10"]').should('have.attr', 'aria-selected', 'true');
+    cy.get('#calendar-ranged [data-vc-date="2023-04-10"] [data-vc-date-btn]').should('not.have.attr', 'aria-selected');
+  });
+
+  it('does not take the focus when a picker is the opening view', () => {
+    cy.visit('/pages/a11y/');
+    cy.get('#calendar-month [data-vc-months-month]').should('exist');
+    cy.document().its('activeElement.tagName').should('eq', 'BODY');
+  });
+
+  it('moves the focus into the picker the user opened', () => {
+    cy.visit('/');
+    cy.get('.vc-year').click();
+    cy.focused().should('have.attr', 'data-vc-years-year');
+  });
+
+  it('keeps the focus on the arrow while browsing the year list', () => {
+    cy.visit('/');
+    cy.get('.vc-year').click();
+    cy.get('[data-vc-arrow="next"]').click();
+    cy.focused().should('have.attr', 'data-vc-arrow', 'next');
+  });
+
+  it('moves the focus with the arrow keys without scrolling the page along', () => {
+    cy.visit('/');
+    cy.get('[data-vc-date-btn][tabindex="0"]').focus();
+    cy.focused().trigger('keydown', { key: 'ArrowRight' });
+    cy.focused().should('have.attr', 'tabindex', '0').and('have.attr', 'data-vc-date-btn');
+    cy.window().its('scrollY').should('eq', 0);
+  });
+
+  it('keeps arrow-key focus inside its grid and leaves disabled dates unfocusable', () => {
+    cy.visit('/pages/a11y/');
+    cy.get('#calendar-locked-titles [data-vc-date-btn][aria-disabled="true"]').first().should('be.disabled');
+
+    cy.get('#calendar-clickable-headers [data-vc-date-btn]').then(($buttons) => {
+      cy.wrap($buttons[0]).focus().trigger('keydown', { key: 'ArrowLeft' });
+      cy.focused().should('have.attr', 'data-vc-date-btn');
+
+      cy.wrap($buttons[$buttons.length - 1])
+        .focus()
+        .trigger('keydown', { key: 'ArrowRight' });
+      cy.focused().should('have.attr', 'data-vc-date-btn');
+    });
+  });
+
+  it('gives a clickable weekday header a target big enough to hit', () => {
+    cy.visit('/pages/a11y/');
+    cy.get('#calendar-clickable-headers [data-vc-week-day-btn]')
+      .first()
+      .then(($btn) => {
+        const { width, height } = $btn[0].getBoundingClientRect();
+        expect(width).to.be.at.least(24);
+        expect(height).to.be.at.least(24);
+      });
+  });
+
+  it('names every time control once, and wraps none of them in an empty label', () => {
+    cy.visit('/');
+    cy.get('#calendar [data-vc="time"] label').should('not.exist');
+    cy.get('#calendar [data-vc="time"] input[name]').then(($inputs) => {
+      const names = [...$inputs].map((input) => (input as HTMLInputElement).name);
+      expect(new Set(names).size, 'duplicate form control name').to.eq(names.length);
+    });
+  });
+
+  it('takes the closed popup out of the focus order and the accessibility tree', () => {
+    cy.visit('/pages/a11y/');
+    cy.get('#calendar-input').click();
+    cy.get('[data-vc-input]').should('not.have.attr', 'inert');
+    cy.get('[data-vc-input]').should('not.have.attr', 'aria-hidden');
+    cy.get('h1').click();
+    cy.get('[data-vc-input]').should('have.attr', 'inert');
+    cy.get('[data-vc-input]').should('have.attr', 'aria-hidden', 'true');
+  });
+
+  it('lets the keyboard walk from the field into the popup and back out with Escape', () => {
+    cy.visit('/pages/a11y/');
+    cy.get('#calendar-input').focus().click();
+    cy.get('[data-vc-input]').should('not.have.attr', 'inert');
+    cy.get('#calendar-input').trigger('keydown', { key: 'ArrowDown' });
+    cy.focused().should('exist');
+    cy.document().then((doc) => {
+      expect(doc.querySelector('[data-vc-input]')?.contains(doc.activeElement)).to.eq(true);
+    });
+    cy.focused().trigger('keydown', { key: 'Escape' });
+    cy.focused().should('have.id', 'calendar-input');
+  });
+
+  it('tells the field that it opens a picker', () => {
+    cy.visit('/pages/a11y/');
+    cy.get('#calendar-input').should('have.attr', 'aria-haspopup', 'dialog').and('not.have.attr', 'aria-expanded');
+    cy.get('#calendar-input').click();
+    cy.get('[data-vc-input]').should('have.attr', 'role', 'dialog');
   });
 });

--- a/cypress/e2e/shadowDom.cy.ts
+++ b/cypress/e2e/shadowDom.cy.ts
@@ -1,3 +1,39 @@
+// Real pointer events are composed, so a synthetic drag has to be as well: without it the
+// pointermove/pointerup pair never leaves the shadow root and window never sees the gesture.
+const dispatch = (el: Element, type: string, clientX: number, clientY: number) =>
+  el.dispatchEvent(
+    new PointerEvent(type, {
+      pointerId: 1,
+      isPrimary: true,
+      button: 0,
+      buttons: type === 'pointerup' ? 0 : 1,
+      clientX,
+      clientY,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    }),
+  );
+
+const swipeInside = (widget: string, dx: number) => {
+  cy.get(widget)
+    .shadow()
+    .find('[data-vc="content"]')
+    .first()
+    .then(($el) => {
+      const box = $el[0].getBoundingClientRect();
+      const x = Math.round(box.left + box.width / 2);
+      const y = Math.round(box.top + box.height / 2);
+      dispatch($el[0], 'pointerdown', x, y);
+      dispatch($el[0], 'pointermove', x + Math.sign(dx) * 12, y);
+      dispatch($el[0], 'pointermove', x + dx, y);
+      cy.wait(250);
+      dispatch($el[0], 'pointerup', x + dx, y);
+    });
+};
+
+const monthOf = (widget: string) => cy.get(widget).shadow().find('[data-vc="month"]').first().invoke('attr', 'data-vc-month');
+
 describe('Shadow DOM support', () => {
   it('renders the popup inside the shadow root, not in document.body', () => {
     cy.visit('/pages/shadow-dom/');
@@ -49,6 +85,31 @@ describe('Shadow DOM support', () => {
     cy.get('#widget-1').shadow().find('[data-vc-shadow-init]').click();
     cy.get('#widget-1').shadow().find('[data-vc-shadow-input]').click();
     cy.get('#widget-1').shadow().find('[data-vc="calendar"]').should('exist').and('not.have.attr', 'data-vc-calendar-hidden');
+  });
+
+  it('collapses and swipes a plain calendar inside the shadow root', () => {
+    cy.visit('/pages/shadow-dom/');
+    cy.get('#widget-5').shadow().find('[data-vc="collapse"]').click();
+    cy.get('#widget-5').shadow().find('[data-vc="calendar"]').should('have.attr', 'data-vc-type', 'week');
+    cy.get('#widget-5').shadow().find('[data-vc="collapse"]').click();
+    cy.get('#widget-5').shadow().find('[data-vc="calendar"]').should('have.attr', 'data-vc-type', 'default');
+
+    monthOf('#widget-5').should('eq', '3');
+    swipeInside('#widget-5', -200);
+    monthOf('#widget-5').should('eq', '4');
+  });
+
+  it('collapses and swipes the popup of an inputMode calendar inside the shadow root', () => {
+    cy.visit('/pages/shadow-dom/');
+    cy.get('#widget-4').shadow().find('[data-vc-shadow-input]').click();
+    cy.get('#widget-4').shadow().find('[data-vc="calendar"]').should('not.have.attr', 'data-vc-calendar-hidden');
+
+    cy.get('#widget-4').shadow().find('[data-vc="collapse"]').click();
+    cy.get('#widget-4').shadow().find('[data-vc="calendar"]').should('have.attr', 'data-vc-type', 'week');
+
+    monthOf('#widget-4').should('eq', '3');
+    swipeInside('#widget-4', -200);
+    cy.get('#widget-4').shadow().find('[data-vc="calendar"]').should('not.have.attr', 'data-vc-calendar-hidden');
   });
 
   it('a plain (non-inputMode) calendar renders directly inside the shadow root and dates are clickable', () => {

--- a/cypress/e2e/weekNumbers.cy.ts
+++ b/cypress/e2e/weekNumbers.cy.ts
@@ -1,3 +1,9 @@
+const getMiddles = (containerSelector: string, itemSelector: string) =>
+  cy
+    .get(containerSelector)
+    .find(itemSelector)
+    .then(($els) => [...$els].map((el) => Math.round(el.getBoundingClientRect().top + el.getBoundingClientRect().height / 2)));
+
 const getRowWeekNumbers = (containerSelector: string) =>
   cy
     .get(containerSelector)
@@ -20,5 +26,21 @@ describe('Week numbers', () => {
   it('firstWeekday=0 (Sunday-start weeks) still numbers rows sequentially with no gaps or duplicates', () => {
     cy.visit('/pages/week-numbers/');
     getRowWeekNumbers('#calendar-sunday-start').should('deep.equal', [22, 23, 24, 25, 26]);
+  });
+
+  it('lines every number up with the row it counts', () => {
+    cy.visit('/pages/week-numbers/');
+    ['#calendar-2026', '#calendar-2025', '#calendar-sunday-start'].forEach((calendar) => {
+      getMiddles(calendar, '[data-vc-dates="row"]').then((rows) => {
+        getMiddles(calendar, '[data-vc-week-number]').should('deep.equal', rows);
+      });
+    });
+  });
+
+  it('lines them up under a clickable weekday header too', () => {
+    cy.visit('/pages/a11y/');
+    getMiddles('#calendar-clickable-headers', '[data-vc-dates="row"]').then((rows) => {
+      getMiddles('#calendar-clickable-headers', '[data-vc-week-number]').should('deep.equal', rows);
+    });
   });
 });

--- a/demo/index.css
+++ b/demo/index.css
@@ -3,6 +3,10 @@
 @tailwind utilities;
 
 @layer components {
+  .skip-link {
+    @apply fixed left-4 top-4 z-50 -translate-y-16 rounded bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-transform focus:translate-y-0 dark:bg-white dark:text-slate-900;
+  }
+
   #calendar {
     @apply shadow-[0_5px_40px_5px_rgb(65_65_65_/_0.1)] dark:shadow-[inset_0_0_0_1px_rgb(255_255_255_/_0.1)];
   }

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="./favicon.svg">
-    <link rel="stylesheet" href="./index.css">
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
+    <link rel="stylesheet" href="./index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,14 +4,24 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="initial-scale=1,width=device-width" />
     <meta name="format-detection" content="telephone=no" />
-    <title>The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript frameworks and libraries.</title>
+    <title>
+      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
+      frameworks and libraries.
+    </title>
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <link rel="stylesheet" href="./index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
-  <body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.</p>
-    <div id="calendar"></div>
+  <body
+    class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
+  >
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.
+      </p>
+      <div id="calendar"></div>
+    </main>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
-    <link rel="stylesheet" href="./index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg">
+    <link rel="stylesheet" href="./index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/a11y/index.html
+++ b/demo/pages/a11y/index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
+    <title>
+      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
+      frameworks and libraries.
+    </title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
+    <script defer src="./main.ts" type="module"></script>
+  </head>
+  <body
+    class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
+  >
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        Every option combination that carries its own ARIA markup, gathered on one page for the accessibility checks.
+      </p>
+      <div class="flex flex-col items-center gap-12">
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>type: 'month'</code> &mdash; a picker as the opening view</figcaption>
+          <div id="calendar-month"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>type: 'year'</code> &mdash; a picker as the opening view</figcaption>
+          <div id="calendar-year"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>onClickWeekDay</code> and <code>onClickWeekNumber</code> &mdash; clickable headers</figcaption>
+          <div id="calendar-clickable-headers"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>selectionDatesMode: 'multiple-ranged'</code> with a range tooltip</figcaption>
+          <div id="calendar-ranged"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>timeControls: 'range'</code> &mdash; sliders, with the inputs disabled</figcaption>
+          <div id="calendar-time-range"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>type: 'multiple'</code> with <code>enableWeekNumbers</code></figcaption>
+          <div id="calendar-multiple-week-numbers"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400">
+            <code>selectionMonthsMode</code> and <code>selectionYearsMode</code> off &mdash; locked titles
+          </figcaption>
+          <div id="calendar-locked-titles"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>popups</code> &mdash; a date carrying extra content</figcaption>
+          <div id="calendar-popups"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>inputMode</code> &mdash; the popup, open and closed</figcaption>
+          <label class="text-sm dark:text-slate-400" for="calendar-input">Pick a date</label>
+          <input id="calendar-input" class="input" type="text" readonly />
+        </figure>
+      </div>
+    </main>
+  </body>
+</html>

--- a/demo/pages/a11y/index.html
+++ b/demo/pages/a11y/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body
@@ -56,7 +56,7 @@
         <figure class="flex flex-col items-center gap-3">
           <figcaption class="text-sm dark:text-slate-400"><code>inputMode</code> &mdash; the popup, open and closed</figcaption>
           <label class="text-sm dark:text-slate-400" for="calendar-input">Pick a date</label>
-          <input id="calendar-input" class="input" type="text" readonly>
+          <input id="calendar-input" class="input" type="text" readonly />
         </figure>
       </div>
     </main>

--- a/demo/pages/a11y/index.html
+++ b/demo/pages/a11y/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body
@@ -59,7 +56,7 @@
         <figure class="flex flex-col items-center gap-3">
           <figcaption class="text-sm dark:text-slate-400"><code>inputMode</code> &mdash; the popup, open and closed</figcaption>
           <label class="text-sm dark:text-slate-400" for="calendar-input">Pick a date</label>
-          <input id="calendar-input" class="input" type="text" readonly />
+          <input id="calendar-input" class="input" type="text" readonly>
         </figure>
       </div>
     </main>

--- a/demo/pages/a11y/main.ts
+++ b/demo/pages/a11y/main.ts
@@ -1,0 +1,35 @@
+import { Calendar, type Options } from '@src/index';
+
+import '@src/styles/index.css';
+
+const base: Options = { selectedMonth: 3, selectedYear: 2023 };
+
+document.addEventListener('DOMContentLoaded', () => {
+  new Calendar('#calendar-month', { ...base, type: 'month' }).init();
+
+  new Calendar('#calendar-year', { ...base, type: 'year' }).init();
+
+  new Calendar('#calendar-clickable-headers', {
+    ...base,
+    enableWeekNumbers: true,
+    onClickWeekDay: () => {},
+    onClickWeekNumber: () => {},
+  }).init();
+
+  new Calendar('#calendar-ranged', {
+    ...base,
+    selectionDatesMode: 'multiple-ranged',
+    selectedDates: ['2023-04-10:2023-04-18'],
+    onCreateDateRangeTooltip: () => 'Selected range',
+  }).init();
+
+  new Calendar('#calendar-time-range', { ...base, selectionTimeMode: 24, timeControls: 'range', selectedTime: '10:30' }).init();
+
+  new Calendar('#calendar-multiple-week-numbers', { ...base, type: 'multiple', enableWeekNumbers: true, displayMonthsCount: 2 }).init();
+
+  new Calendar('#calendar-locked-titles', { ...base, selectionMonthsMode: false, selectionYearsMode: false }).init();
+
+  new Calendar('#calendar-popups', { ...base, popups: { '2023-04-12': { modifier: '', html: '<b>Meeting</b> at noon' } } }).init();
+
+  new Calendar('#calendar-input', { ...base, inputMode: true }).init();
+});

--- a/demo/pages/animation/index.html
+++ b/demo/pages/animation/index.html
@@ -15,27 +15,30 @@
   <body
     class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
   >
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
-      A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.
-    </p>
-    <div class="flex flex-col items-center gap-12">
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>animation: true</code> &mdash; defaults</figcaption>
-        <div id="calendar-animated"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400">no <code>animation</code> &mdash; control</figcaption>
-        <div id="calendar-static"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>type: 'multiple'</code> &mdash; one timing shared by both groups</figcaption>
-        <div id="calendar-multiple"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400">custom timings &mdash; overshooting slide, calm cross-fade</figcaption>
-        <div id="calendar-custom"></div>
-      </figure>
-    </div>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.
+      </p>
+      <div class="flex flex-col items-center gap-12">
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>animation: true</code> &mdash; defaults</figcaption>
+          <div id="calendar-animated"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400">no <code>animation</code> &mdash; control</figcaption>
+          <div id="calendar-static"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>type: 'multiple'</code> &mdash; one timing shared by both groups</figcaption>
+          <div id="calendar-multiple"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400">custom timings &mdash; overshooting slide, calm cross-fade</figcaption>
+          <div id="calendar-custom"></div>
+        </figure>
+      </div>
+    </main>
   </body>
 </html>

--- a/demo/pages/animation/index.html
+++ b/demo/pages/animation/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/animation/index.html
+++ b/demo/pages/animation/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/disable-dates-gaps/index.html
+++ b/demo/pages/disable-dates-gaps/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/disable-dates-gaps/index.html
+++ b/demo/pages/disable-dates-gaps/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/disable-dates-gaps/index.html
+++ b/demo/pages/disable-dates-gaps/index.html
@@ -4,14 +4,24 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="initial-scale=1,width=device-width" />
     <meta name="format-detection" content="telephone=no" />
-    <title>The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript frameworks and libraries.</title>
+    <title>
+      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
+      frameworks and libraries.
+    </title>
     <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
     <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
-  <body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">Issue #407 repro. Clicking 2022-01-29 should NOT select past the gap (2022-01-16 to 2022-01-23 are disabled).</p>
-    <div id="calendar"></div>
+  <body
+    class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
+  >
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        Issue #407 repro. Clicking 2022-01-29 should NOT select past the gap (2022-01-16 to 2022-01-23 are disabled).
+      </p>
+      <div id="calendar"></div>
+    </main>
   </body>
 </html>

--- a/demo/pages/gestures/index.html
+++ b/demo/pages/gestures/index.html
@@ -15,55 +15,60 @@
   <body
     class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
   >
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
-      A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.
-    </p>
-    <div class="flex flex-col items-center gap-12">
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>enableCollapse</code> and <code>enableSwipe</code> &mdash; both gestures</figcaption>
-        <div id="calendar-gestures"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>enableCollapse</code> &mdash; starting collapsed</figcaption>
-        <div id="calendar-collapsed"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>enableSwipe</code> with <code>type: 'multiple'</code></figcaption>
-        <div id="calendar-multiple"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>enableSwipe</code> with <code>dateMax</code> &mdash; cannot be dragged past the bound</figcaption>
-        <div id="calendar-bounded"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400">both gestures, no <code>animation</code></figcaption>
-        <div id="calendar-plain"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>enableCollapse</code> on its own</figcaption>
-        <div id="calendar-collapse-only"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>enableSwipe</code> with ranged selection</figcaption>
-        <div id="calendar-range"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400">no gestures &mdash; control</figcaption>
-        <div id="calendar-static"></div>
-        <button id="btn-enable-gestures" type="button" class="rounded-lg border border-slate-500 px-3 py-1 text-sm">Enable gestures dynamically</button>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400">both gestures in <code>inputMode</code></figcaption>
-        <input id="calendar-input-gestures" class="input" type="text" readonly />
-      </figure>
-      <div class="flex flex-col items-center gap-3">
-        <button id="btn-invalid-collapse" type="button" class="rounded-lg border border-slate-500 px-3 py-1 text-sm">
-          init enableCollapse with type: 'multiple'
-        </button>
-        <pre id="log" class="text-xs dark:text-slate-400"></pre>
-        <div id="calendar-invalid"></div>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.
+      </p>
+      <div class="flex flex-col items-center gap-12">
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>enableCollapse</code> and <code>enableSwipe</code> &mdash; both gestures</figcaption>
+          <div id="calendar-gestures"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>enableCollapse</code> &mdash; starting collapsed</figcaption>
+          <div id="calendar-collapsed"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>enableSwipe</code> with <code>type: 'multiple'</code></figcaption>
+          <div id="calendar-multiple"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400">
+            <code>enableSwipe</code> with <code>dateMax</code> &mdash; cannot be dragged past the bound
+          </figcaption>
+          <div id="calendar-bounded"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400">both gestures, no <code>animation</code></figcaption>
+          <div id="calendar-plain"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>enableCollapse</code> on its own</figcaption>
+          <div id="calendar-collapse-only"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>enableSwipe</code> with ranged selection</figcaption>
+          <div id="calendar-range"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400">no gestures &mdash; control</figcaption>
+          <div id="calendar-static"></div>
+          <button id="btn-enable-gestures" type="button" class="rounded-lg border border-slate-500 px-3 py-1 text-sm">Enable gestures dynamically</button>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400">both gestures in <code>inputMode</code></figcaption>
+          <input id="calendar-input-gestures" class="input" type="text" aria-label="Pick a date" readonly />
+        </figure>
+        <div class="flex flex-col items-center gap-3">
+          <button id="btn-invalid-collapse" type="button" class="rounded-lg border border-slate-500 px-3 py-1 text-sm">
+            init enableCollapse with type: 'multiple'
+          </button>
+          <pre id="log" class="text-xs dark:text-slate-400"></pre>
+          <div id="calendar-invalid"></div>
+        </div>
       </div>
-    </div>
+    </main>
   </body>
 </html>

--- a/demo/pages/gestures/index.html
+++ b/demo/pages/gestures/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body
@@ -56,7 +56,7 @@
         </figure>
         <figure class="flex flex-col items-center gap-3">
           <figcaption class="text-sm dark:text-slate-400">both gestures in <code>inputMode</code></figcaption>
-          <input id="calendar-input-gestures" class="input" type="text" aria-label="Pick a date" readonly>
+          <input id="calendar-input-gestures" class="input" type="text" aria-label="Pick a date" readonly />
         </figure>
         <div class="flex flex-col items-center gap-3">
           <button id="btn-invalid-collapse" type="button" class="rounded-lg border border-slate-500 px-3 py-1 text-sm">

--- a/demo/pages/gestures/index.html
+++ b/demo/pages/gestures/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body
@@ -59,7 +56,7 @@
         </figure>
         <figure class="flex flex-col items-center gap-3">
           <figcaption class="text-sm dark:text-slate-400">both gestures in <code>inputMode</code></figcaption>
-          <input id="calendar-input-gestures" class="input" type="text" aria-label="Pick a date" readonly />
+          <input id="calendar-input-gestures" class="input" type="text" aria-label="Pick a date" readonly>
         </figure>
         <div class="flex flex-col items-center gap-3">
           <button id="btn-invalid-collapse" type="button" class="rounded-lg border border-slate-500 px-3 py-1 text-sm">

--- a/demo/pages/input/index.html
+++ b/demo/pages/input/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body
@@ -22,7 +22,7 @@
       <div class="flex flex-col items-center gap-7">
         <div>
           <label for="calendar-input">Datepicker tag 'input'</label>
-          <input id="calendar-input" class="input" name="calendar" type="text" readonly>
+          <input id="calendar-input" class="input" name="calendar" type="text" readonly />
         </div>
         <div>
           <div>Datepicker tag 'div'</div>

--- a/demo/pages/input/index.html
+++ b/demo/pages/input/index.html
@@ -4,24 +4,34 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="initial-scale=1,width=device-width" />
     <meta name="format-detection" content="telephone=no" />
-    <title>The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript frameworks and libraries.</title>
+    <title>
+      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
+      frameworks and libraries.
+    </title>
     <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
     <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
-  <body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.</p>
-    <button id="set-date" type="button" class="mb-7 w-64 border-gray-200 border-2">Dynamically Set Date</button>
-    <div class="flex flex-col items-center gap-7">
-      <label>
-        <div>Datepicker tag 'input'</div>
-        <input id="calendar-input" class="input" name="calendar" type="text" readonly />
-      </label>
-      <div>
-        <div>Datepicker tag 'div'</div>
-        <div id="calendar-div" class="input"></div>
+  <body
+    class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
+  >
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.
+      </p>
+      <button id="set-date" type="button" class="mb-7 w-64 border-gray-200 border-2">Dynamically Set Date</button>
+      <div class="flex flex-col items-center gap-7">
+        <label>
+          <div>Datepicker tag 'input'</div>
+          <input id="calendar-input" class="input" name="calendar" type="text" readonly />
+        </label>
+        <div>
+          <div>Datepicker tag 'div'</div>
+          <div id="calendar-div" class="input"></div>
+        </div>
       </div>
-    </div>
+    </main>
   </body>
 </html>

--- a/demo/pages/input/index.html
+++ b/demo/pages/input/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body
@@ -23,10 +20,10 @@
       </p>
       <button id="set-date" type="button" class="mb-7 w-64 border-gray-200 border-2">Dynamically Set Date</button>
       <div class="flex flex-col items-center gap-7">
-        <label>
-          <div>Datepicker tag 'input'</div>
-          <input id="calendar-input" class="input" name="calendar" type="text" readonly />
-        </label>
+        <div>
+          <label for="calendar-input">Datepicker tag 'input'</label>
+          <input id="calendar-input" class="input" name="calendar" type="text" readonly>
+        </div>
         <div>
           <div>Datepicker tag 'div'</div>
           <div id="calendar-div" class="input"></div>

--- a/demo/pages/lang/index.html
+++ b/demo/pages/lang/index.html
@@ -4,15 +4,24 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="initial-scale=1,width=device-width" />
     <meta name="format-detection" content="telephone=no" />
-    <title>Vanilla Calendar - Средство выбора даты и времени на чистом JavaScript с использованием TypeScript, поддерживает любую структуру и библиотеку JS.</title>
+    <title>
+      Vanilla Calendar - Средство выбора даты и времени на чистом JavaScript с использованием TypeScript, поддерживает любую структуру и библиотеку JS.
+    </title>
     <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
     <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
-  <body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">Средство выбора даты и времени на чистом JavaScript с использованием TypeScript, поддерживает любую структуру и библиотеку JS.</p>
-    <button type="button" id="set-options" class="mb-7 w-64 border-gray-200 border-2">Установить настройки</button>
-    <div id="calendar"></div>
+  <body
+    class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
+  >
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        Средство выбора даты и времени на чистом JavaScript с использованием TypeScript, поддерживает любую структуру и библиотеку JS.
+      </p>
+      <button type="button" id="set-options" class="mb-7 w-64 border-gray-200 border-2">Установить настройки</button>
+      <div id="calendar"></div>
+    </main>
   </body>
 </html>

--- a/demo/pages/lang/index.html
+++ b/demo/pages/lang/index.html
@@ -1,14 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ru">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      Vanilla Calendar - Средство выбора даты и времени на чистом JavaScript с использованием TypeScript, поддерживает любую структуру и библиотеку JS.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — Выбор даты и времени</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/lang/index.html
+++ b/demo/pages/lang/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ru">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — Выбор даты и времени</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/lifecycle/index.html
+++ b/demo/pages/lifecycle/index.html
@@ -15,15 +15,18 @@
   <body
     class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
   >
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
-      Calling init() or destroy() more than once on the same instance should throw, not corrupt the DOM.
-    </p>
-    <div id="calendar"></div>
-    <div class="flex gap-2 mt-6">
-      <button id="btn-init" type="button" class="input">Init</button>
-      <button id="btn-destroy" type="button" class="input">Destroy</button>
-    </div>
-    <pre id="log" class="mt-6 text-left text-sm"></pre>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        Calling init() or destroy() more than once on the same instance should throw, not corrupt the DOM.
+      </p>
+      <div id="calendar"></div>
+      <div class="flex gap-2 mt-6">
+        <button id="btn-init" type="button" class="input">Init</button>
+        <button id="btn-destroy" type="button" class="input">Destroy</button>
+      </div>
+      <pre id="log" class="mt-6 text-left text-sm"></pre>
+    </main>
   </body>
 </html>

--- a/demo/pages/lifecycle/index.html
+++ b/demo/pages/lifecycle/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/lifecycle/index.html
+++ b/demo/pages/lifecycle/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/multiple/index.html
+++ b/demo/pages/multiple/index.html
@@ -4,14 +4,24 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="initial-scale=1,width=device-width" />
     <meta name="format-detection" content="telephone=no" />
-    <title>The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript frameworks and libraries.</title>
+    <title>
+      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
+      frameworks and libraries.
+    </title>
     <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
     <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
-  <body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.</p>
-    <div id="calendar"></div>
+  <body
+    class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
+  >
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.
+      </p>
+      <div id="calendar"></div>
+    </main>
   </body>
 </html>

--- a/demo/pages/multiple/index.html
+++ b/demo/pages/multiple/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/multiple/index.html
+++ b/demo/pages/multiple/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/popups-range/index.html
+++ b/demo/pages/popups-range/index.html
@@ -4,14 +4,24 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="initial-scale=1,width=device-width" />
     <meta name="format-detection" content="telephone=no" />
-    <title>The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript frameworks and libraries.</title>
+    <title>
+      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
+      frameworks and libraries.
+    </title>
     <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
     <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
-  <body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">Issue #406 repro: popups with a "start:end" range key should apply the same popup to every day in the range.</p>
-    <div id="calendar"></div>
+  <body
+    class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
+  >
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        Issue #406 repro: popups with a "start:end" range key should apply the same popup to every day in the range.
+      </p>
+      <div id="calendar"></div>
+    </main>
   </body>
 </html>

--- a/demo/pages/popups-range/index.html
+++ b/demo/pages/popups-range/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/popups-range/index.html
+++ b/demo/pages/popups-range/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/shadow-dom/index.html
+++ b/demo/pages/shadow-dom/index.html
@@ -15,15 +15,18 @@
   <body
     class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
   >
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
-      Issue #381 repro: calendar instances fully encapsulated inside separate Shadow DOM web components.
-    </p>
-    <div class="flex gap-10 items-start">
-      <shadow-calendar-input id="widget-1"></shadow-calendar-input>
-      <shadow-calendar-input id="widget-2"></shadow-calendar-input>
-      <shadow-calendar-plain id="widget-3"></shadow-calendar-plain>
-    </div>
-    <button id="light-dom-outside" type="button" class="mt-24">Outside click target (light DOM)</button>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        Issue #381 repro: calendar instances fully encapsulated inside separate Shadow DOM web components.
+      </p>
+      <div class="flex gap-10 items-start">
+        <shadow-calendar-input id="widget-1"></shadow-calendar-input>
+        <shadow-calendar-input id="widget-2"></shadow-calendar-input>
+        <shadow-calendar-plain id="widget-3"></shadow-calendar-plain>
+      </div>
+      <button id="light-dom-outside" type="button" class="mt-24">Outside click target (light DOM)</button>
+    </main>
   </body>
 </html>

--- a/demo/pages/shadow-dom/index.html
+++ b/demo/pages/shadow-dom/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/shadow-dom/index.html
+++ b/demo/pages/shadow-dom/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body
@@ -22,6 +22,10 @@
         <shadow-calendar-input id="widget-1"></shadow-calendar-input>
         <shadow-calendar-input id="widget-2"></shadow-calendar-input>
         <shadow-calendar-plain id="widget-3"></shadow-calendar-plain>
+      </div>
+      <div class="mt-12 flex items-start gap-10">
+        <shadow-calendar-gestures-input id="widget-4"></shadow-calendar-gestures-input>
+        <shadow-calendar-gestures-plain id="widget-5"></shadow-calendar-gestures-plain>
       </div>
       <button id="light-dom-outside" type="button" class="mt-24">Outside click target (light DOM)</button>
     </main>

--- a/demo/pages/shadow-dom/main.ts
+++ b/demo/pages/shadow-dom/main.ts
@@ -91,3 +91,80 @@ class ShadowCalendarPlain extends HTMLElement {
 }
 
 customElements.define('shadow-calendar-plain', ShadowCalendarPlain);
+
+// Gestures inside a shadow root: the pointer listeners live on the calendar element, but the
+// move/up pair is bound to window, so both have to survive crossing the shadow boundary.
+const gestureOptions: Options = {
+  animation: true,
+  enableCollapse: true,
+  enableSwipe: true,
+  selectedTheme: 'system',
+  selectedDates: ['2023-04-19'],
+  selectedMonth: 3,
+  selectedYear: 2023,
+};
+
+class ShadowCalendarGesturesInput extends HTMLElement {
+  calendar?: Calendar;
+
+  connectedCallback() {
+    const shadow = this.attachShadow({ mode: 'open' });
+
+    const style = document.createElement('style');
+    style.textContent = `${calendarStyles} input { padding: 8px; font-size: 14px; }`;
+    shadow.appendChild(style);
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `
+      <div>Shadow DOM + inputMode + gestures (${this.id})</div>
+      <input type="text" readonly aria-label="Pick a date" data-vc-shadow-input>
+    `;
+    shadow.appendChild(wrapper);
+
+    const inputEl = shadow.querySelector('[data-vc-shadow-input]') as HTMLInputElement;
+
+    this.calendar = new Calendar(inputEl, {
+      ...gestureOptions,
+      inputMode: true,
+      positionToInput: 'auto',
+      onChangeToInput: (self) => {
+        inputEl.value = self.context.selectedDates[0] ?? '';
+      },
+    });
+    this.calendar.init();
+  }
+
+  disconnectedCallback() {
+    this.calendar?.destroy();
+  }
+}
+
+customElements.define('shadow-calendar-gestures-input', ShadowCalendarGesturesInput);
+
+class ShadowCalendarGesturesPlain extends HTMLElement {
+  calendar?: Calendar;
+
+  connectedCallback() {
+    const shadow = this.attachShadow({ mode: 'open' });
+
+    const style = document.createElement('style');
+    style.textContent = calendarStyles;
+    shadow.appendChild(style);
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `
+      <div>Shadow DOM + gestures (${this.id})</div>
+      <div data-vc-shadow-plain></div>
+    `;
+    shadow.appendChild(wrapper);
+
+    this.calendar = new Calendar(shadow.querySelector('[data-vc-shadow-plain]') as HTMLElement, gestureOptions);
+    this.calendar.init();
+  }
+
+  disconnectedCallback() {
+    this.calendar?.destroy();
+  }
+}
+
+customElements.define('shadow-calendar-gestures-plain', ShadowCalendarGesturesPlain);

--- a/demo/pages/week-numbers/index.html
+++ b/demo/pages/week-numbers/index.html
@@ -4,18 +4,28 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="initial-scale=1,width=device-width" />
     <meta name="format-detection" content="telephone=no" />
-    <title>The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript frameworks and libraries.</title>
+    <title>
+      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
+      frameworks and libraries.
+    </title>
     <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
     <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
-  <body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.</p>
-    <div class="flex flex-col items-center gap-10">
-      <div id="calendar-2026"></div>
-      <div id="calendar-2025"></div>
-      <div id="calendar-sunday-start"></div>
-    </div>
+  <body
+    class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
+  >
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.
+      </p>
+      <div class="flex flex-col items-center gap-10">
+        <div id="calendar-2026"></div>
+        <div id="calendar-2025"></div>
+        <div id="calendar-sunday-start"></div>
+      </div>
+    </main>
   </body>
 </html>

--- a/demo/pages/week-numbers/index.html
+++ b/demo/pages/week-numbers/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/week-numbers/index.html
+++ b/demo/pages/week-numbers/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/week/index.html
+++ b/demo/pages/week/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1,width=device-width" />
-    <meta name="format-detection" content="telephone=no" />
-    <title>
-      The Vanilla Calendar Pro is a versatile JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript
-      frameworks and libraries.
-    </title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
-    <link rel="stylesheet" href="../../index.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
+    <meta name="format-detection" content="telephone=no">
+    <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
+    <link rel="stylesheet" href="../../index.css">
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/week/index.html
+++ b/demo/pages/week/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="initial-scale=1,width=device-width">
-    <meta name="format-detection" content="telephone=no">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <meta name="format-detection" content="telephone=no" />
     <title>Vanilla Calendar Pro — JavaScript Date &amp; Time Picker</title>
-    <link rel="icon" type="image/svg+xml" href="../../favicon.svg">
-    <link rel="stylesheet" href="../../index.css">
+    <link rel="icon" type="image/svg+xml" href="../../favicon.svg" />
+    <link rel="stylesheet" href="../../index.css" />
     <script defer src="./main.ts" type="module"></script>
   </head>
   <body

--- a/demo/pages/week/index.html
+++ b/demo/pages/week/index.html
@@ -15,28 +15,31 @@
   <body
     class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white"
   >
-    <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
-    <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
-      A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.
-    </p>
-    <div class="flex flex-col items-center gap-12">
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>type: 'week'</code> &mdash; a standalone week strip</figcaption>
-        <div id="calendar-week"></div>
-        <button id="btn-sunday-first" type="button" class="rounded-lg border border-slate-500 px-3 py-1 text-sm">Set Sunday as the first weekday</button>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>type: 'week'</code> &mdash; with week numbers and a selected date</figcaption>
-        <div id="calendar-week-numbers"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400">a month, for comparison</figcaption>
-        <div id="calendar-month"></div>
-      </figure>
-      <figure class="flex flex-col items-center gap-3">
-        <figcaption class="text-sm dark:text-slate-400"><code>type: 'week'</code> &mdash; year switching disabled</figcaption>
-        <div id="calendar-week-year-locked"></div>
-      </figure>
-    </div>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" class="flex w-full flex-col items-center">
+      <h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar Pro</h1>
+      <p class="block max-w-[700px] text-lg mb-12 dark:text-slate-400">
+        A universal JavaScript date and time picker component with TypeScript support, making it compatible with any JavaScript framework and library.
+      </p>
+      <div class="flex flex-col items-center gap-12">
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>type: 'week'</code> &mdash; a standalone week strip</figcaption>
+          <div id="calendar-week"></div>
+          <button id="btn-sunday-first" type="button" class="rounded-lg border border-slate-500 px-3 py-1 text-sm">Set Sunday as the first weekday</button>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>type: 'week'</code> &mdash; with week numbers and a selected date</figcaption>
+          <div id="calendar-week-numbers"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400">a month, for comparison</figcaption>
+          <div id="calendar-month"></div>
+        </figure>
+        <figure class="flex flex-col items-center gap-3">
+          <figcaption class="text-sm dark:text-slate-400"><code>type: 'week'</code> &mdash; year switching disabled</figcaption>
+          <div id="calendar-week-year-locked"></div>
+        </figure>
+      </div>
+    </main>
   </body>
 </html>

--- a/docs/en/reference/layouts.mdx
+++ b/docs/en/reference/layouts.mdx
@@ -25,9 +25,9 @@ Layouts allow you to almost completely change the DOM structure of the calendar 
 new Calendar('#calendar', {
   layouts: {
     default: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [month] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -64,15 +64,15 @@ This is the default template for displaying one month and its dates.
 new Calendar('#calendar', {
   layouts: {
     multiple: `
-      <div class="${self.styles.controls}" data-vc="controls" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.controls}" data-vc="controls" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [month] />
         <#ArrowNext [month] />
       </div>
       <div class="${self.styles.grid}" data-vc="grid">
         <#Multiple>
-          <div class="${self.styles.column}" data-vc="column" role="region">
+          <div class="${self.styles.column}" data-vc="column" role="group">
             <div class="${self.styles.header}" data-vc="header">
-              <div class="${self.styles.headerContent}" data-vc-header="content">
+              <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
                 <#Month />
                 <#Year />
               </div>
@@ -110,8 +110,8 @@ This is the default template for displaying multiple months and their dates.
 new Calendar('#calendar', {
   layouts: {
     month: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -142,9 +142,9 @@ This is the default template for selecting a month.
 new Calendar('#calendar', {
   layouts: {
     year: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [year] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -176,9 +176,9 @@ This is the default template for selecting a year.
 new Calendar('#calendar', {
   layouts: {
     week: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [week] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>

--- a/docs/en/reference/layouts.mdx
+++ b/docs/en/reference/layouts.mdx
@@ -43,8 +43,8 @@ new Calendar('#calendar', {
       </div>
       <#Collapse />
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -89,8 +89,8 @@ new Calendar('#calendar', {
         <#DateRangeTooltip />
       </div>
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -121,8 +121,8 @@ new Calendar('#calendar', {
           <#Months />
         </div>
       </div>
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -155,8 +155,8 @@ new Calendar('#calendar', {
           <#Years />
         </div>
       </div>
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -194,8 +194,8 @@ new Calendar('#calendar', {
       </div>
       <#Collapse />
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 

--- a/docs/en/reference/styles.mdx
+++ b/docs/en/reference/styles.mdx
@@ -44,6 +44,7 @@ new Calendar('#calendar', {
     // Week row / week numbers
     week: 'vc-week',
     weekDay: 'vc-week__day',
+    weekDayBtn: 'vc-week__day-btn',
     weekNumbers: 'vc-week-numbers',
     weekNumbersTitle: 'vc-week-numbers__title',
     weekNumbersContent: 'vc-week-numbers__content',

--- a/docs/ko/reference/layouts.mdx
+++ b/docs/ko/reference/layouts.mdx
@@ -25,9 +25,9 @@ section: 7
 new Calendar('#calendar', {
   layouts: {
     default: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [month] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -64,15 +64,15 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     multiple: `
-      <div class="${self.styles.controls}" data-vc="controls" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.controls}" data-vc="controls" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [month] />
         <#ArrowNext [month] />
       </div>
       <div class="${self.styles.grid}" data-vc="grid">
         <#Multiple>
-          <div class="${self.styles.column}" data-vc="column" role="region">
+          <div class="${self.styles.column}" data-vc="column" role="group">
             <div class="${self.styles.header}" data-vc="header">
-              <div class="${self.styles.headerContent}" data-vc-header="content">
+              <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
                 <#Month />
                 <#Year />
               </div>
@@ -110,8 +110,8 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     month: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -142,9 +142,9 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     year: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [year] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -176,9 +176,9 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     week: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [week] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>

--- a/docs/ko/reference/layouts.mdx
+++ b/docs/ko/reference/layouts.mdx
@@ -43,8 +43,8 @@ new Calendar('#calendar', {
       </div>
       <#Collapse />
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -89,8 +89,8 @@ new Calendar('#calendar', {
         <#DateRangeTooltip />
       </div>
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -121,8 +121,8 @@ new Calendar('#calendar', {
           <#Months />
         </div>
       </div>
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -155,8 +155,8 @@ new Calendar('#calendar', {
           <#Years />
         </div>
       </div>
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -194,8 +194,8 @@ new Calendar('#calendar', {
       </div>
       <#Collapse />
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 

--- a/docs/ko/reference/styles.mdx
+++ b/docs/ko/reference/styles.mdx
@@ -44,6 +44,7 @@ new Calendar('#calendar', {
     // 주 행 / 주 번호
     week: 'vc-week',
     weekDay: 'vc-week__day',
+    weekDayBtn: 'vc-week__day-btn',
     weekNumbers: 'vc-week-numbers',
     weekNumbersTitle: 'vc-week-numbers__title',
     weekNumbersContent: 'vc-week-numbers__content',

--- a/docs/ru/reference/layouts.mdx
+++ b/docs/ru/reference/layouts.mdx
@@ -25,9 +25,9 @@ section: 7
 new Calendar('#calendar', {
   layouts: {
     default: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [month] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -64,15 +64,15 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     multiple: `
-      <div class="${self.styles.controls}" data-vc="controls" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.controls}" data-vc="controls" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [month] />
         <#ArrowNext [month] />
       </div>
       <div class="${self.styles.grid}" data-vc="grid">
         <#Multiple>
-          <div class="${self.styles.column}" data-vc="column" role="region">
+          <div class="${self.styles.column}" data-vc="column" role="group">
             <div class="${self.styles.header}" data-vc="header">
-              <div class="${self.styles.headerContent}" data-vc-header="content">
+              <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
                 <#Month />
                 <#Year />
               </div>
@@ -110,8 +110,8 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     month: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -142,9 +142,9 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     year: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [year] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -176,9 +176,9 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     week: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [week] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>

--- a/docs/ru/reference/layouts.mdx
+++ b/docs/ru/reference/layouts.mdx
@@ -43,8 +43,8 @@ new Calendar('#calendar', {
       </div>
       <#Collapse />
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -89,8 +89,8 @@ new Calendar('#calendar', {
         <#DateRangeTooltip />
       </div>
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -121,8 +121,8 @@ new Calendar('#calendar', {
           <#Months />
         </div>
       </div>
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -155,8 +155,8 @@ new Calendar('#calendar', {
           <#Years />
         </div>
       </div>
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -194,8 +194,8 @@ new Calendar('#calendar', {
       </div>
       <#Collapse />
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 

--- a/docs/ru/reference/styles.mdx
+++ b/docs/ru/reference/styles.mdx
@@ -44,6 +44,7 @@ new Calendar('#calendar', {
     // Строка недели / номера недель
     week: 'vc-week',
     weekDay: 'vc-week__day',
+    weekDayBtn: 'vc-week__day-btn',
     weekNumbers: 'vc-week-numbers',
     weekNumbersTitle: 'vc-week-numbers__title',
     weekNumbersContent: 'vc-week-numbers__content',

--- a/docs/zh/reference/layouts.mdx
+++ b/docs/zh/reference/layouts.mdx
@@ -25,9 +25,9 @@ section: 7
 new Calendar('#calendar', {
   layouts: {
     default: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [month] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -64,15 +64,15 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     multiple: `
-      <div class="${self.styles.controls}" data-vc="controls" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.controls}" data-vc="controls" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [month] />
         <#ArrowNext [month] />
       </div>
       <div class="${self.styles.grid}" data-vc="grid">
         <#Multiple>
-          <div class="${self.styles.column}" data-vc="column" role="region">
+          <div class="${self.styles.column}" data-vc="column" role="group">
             <div class="${self.styles.header}" data-vc="header">
-              <div class="${self.styles.headerContent}" data-vc-header="content">
+              <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
                 <#Month />
                 <#Year />
               </div>
@@ -110,8 +110,8 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     month: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -142,9 +142,9 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     year: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [year] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>
@@ -176,9 +176,9 @@ new Calendar('#calendar', {
 new Calendar('#calendar', {
   layouts: {
     week: `
-      <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+      <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
         <#ArrowPrev [week] />
-        <div class="${self.styles.headerContent}" data-vc-header="content">
+        <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
           <#Month />
           <#Year />
         </div>

--- a/docs/zh/reference/layouts.mdx
+++ b/docs/zh/reference/layouts.mdx
@@ -43,8 +43,8 @@ new Calendar('#calendar', {
       </div>
       <#Collapse />
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -89,8 +89,8 @@ new Calendar('#calendar', {
         <#DateRangeTooltip />
       </div>
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -121,8 +121,8 @@ new Calendar('#calendar', {
           <#Months />
         </div>
       </div>
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -155,8 +155,8 @@ new Calendar('#calendar', {
           <#Years />
         </div>
       </div>
-    `
-  }
+    `,
+  },
 });
 ```
 
@@ -194,8 +194,8 @@ new Calendar('#calendar', {
       </div>
       <#Collapse />
       <#ControlTime />
-    `
-  }
+    `,
+  },
 });
 ```
 

--- a/docs/zh/reference/styles.mdx
+++ b/docs/zh/reference/styles.mdx
@@ -44,6 +44,7 @@ new Calendar('#calendar', {
     // 星期行 / 周数
     week: 'vc-week',
     weekDay: 'vc-week__day',
+    weekDayBtn: 'vc-week__day-btn',
     weekNumbers: 'vc-week-numbers',
     weekNumbersTitle: 'vc-week-numbers__title',
     weekNumbersContent: 'vc-week-numbers__content',

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
     "lint:fix": "ESLINT_USE_FLAT_CONFIG=true npx eslint . --fix",
     "prettier": "prettier . --check --ignore-unknown",
     "prettier:fix": "prettier . -w",
-    "cypress:open": "cypress open",
-    "cypress:run": "cypress run",
-    "test:cypress": "start-server-and-test dev http://localhost:5173 cypress:run"
+    "cypress:open": "env -u ELECTRON_RUN_AS_NODE cypress open",
+    "cypress:run": "env -u ELECTRON_RUN_AS_NODE cypress run",
+    "test:cypress": "start-server-and-test dev http://localhost:5173 cypress:run",
+    "test:cypress:a11y": "start-server-and-test dev http://localhost:5173 \"npm run cypress:run -- --spec cypress/e2e/a11y.cy.ts\""
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",

--- a/package/src/scripts/components/TimeInput.ts
+++ b/package/src/scripts/components/TimeInput.ts
@@ -1,7 +1,7 @@
 const TimeInput = (name: string, CSSClass: string, labels: { [key: string]: string }, value: string, range: boolean) => `
-  <label class="${CSSClass}" data-vc-time-input="${name}">
+  <div class="${CSSClass}" data-vc-time-input="${name}">
     <input type="text" name="${name}" maxlength="2" aria-label="${labels[`input${name.charAt(0).toUpperCase() + name.slice(1)}`]}" value="${value}" ${range ? 'disabled' : ''}>
-  </label>
+  </div>
 `;
 
 export default TimeInput;

--- a/package/src/scripts/components/TimeRange.ts
+++ b/package/src/scripts/components/TimeRange.ts
@@ -1,7 +1,7 @@
 const TimeRange = (name: string, CSSClass: string, labels: { [key: string]: string }, min: number, max: number, step: number, value: string) => `
-  <label class="${CSSClass}" data-vc-time-range="${name}">
-    <input type="range" name="${name}" min="${min}" max="${max}" step="${step}" aria-label="${labels[`range${name.charAt(0).toUpperCase() + name.slice(1)}`]}" value="${value}">
-  </label>
+  <div class="${CSSClass}" data-vc-time-range="${name}">
+    <input type="range" min="${min}" max="${max}" step="${step}" aria-label="${labels[`range${name.charAt(0).toUpperCase() + name.slice(1)}`]}" value="${value}">
+  </div>
 `;
 
 export default TimeRange;

--- a/package/src/scripts/components/WeekNumbers.ts
+++ b/package/src/scripts/components/WeekNumbers.ts
@@ -1,6 +1,6 @@
 import type { Calendar } from '@src/index';
 
 const WeekNumbers = (self: Calendar) =>
-  self.enableWeekNumbers ? `<div class="${self.styles.weekNumbers}" data-vc-week="numbers" role="row" aria-label="${self.labels.weekNumber}"></div>` : '';
+  self.enableWeekNumbers ? `<div class="${self.styles.weekNumbers}" data-vc-week="numbers" role="group" aria-label="${self.labels.weekNumber}"></div>` : '';
 
 export default WeekNumbers;

--- a/package/src/scripts/creators/createDates/createDatePopup.ts
+++ b/package/src/scripts/creators/createDates/createDatePopup.ts
@@ -14,7 +14,6 @@ const handleDay = (self: Calendar, date: string, dateInfo: Popup, datesEl: HTMLE
   datePopup.className = self.styles.datePopup;
   datePopup.dataset.vcDatePopup = '';
   datePopup.innerHTML = self.sanitizerHTML(dateInfo.html);
-  dateBtnEl.ariaExpanded = 'true';
   dateBtnEl.ariaLabel = `${dateBtnEl.ariaLabel}, ${datePopup?.textContent?.replace(/^\s+|\s+(?=\s)|\s+$/g, '').replace(/&nbsp;/g, ' ')}`;
   dateEl.appendChild(datePopup);
 

--- a/package/src/scripts/creators/createDates/createDates.ts
+++ b/package/src/scripts/creators/createDates/createDates.ts
@@ -4,6 +4,7 @@ import createDatesFromNextMonth from '@scripts/creators/createDates/createDatesF
 import createDatesFromPrevMonth from '@scripts/creators/createDates/createDatesFromPrevMonth';
 import createWeekDates from '@scripts/creators/createDates/createWeekDates';
 import createWeekNumbers from '@scripts/creators/createWeekNumbers';
+import updateRovingTabIndex from '@scripts/utils/rovingTabIndex';
 import type { Calendar } from '@src/index';
 
 const createDates = (self: Calendar) => {
@@ -66,6 +67,8 @@ const createDates = (self: Calendar) => {
     createDatePopup(self, datesEl);
     createWeekNumbers(self, firstDayWeek, days, weekNumbersEls[index], datesEl);
   });
+
+  updateRovingTabIndex(self);
 };
 
 export default createDates;

--- a/package/src/scripts/creators/createDates/setDateModifier.ts
+++ b/package/src/scripts/creators/createDates/setDateModifier.ts
@@ -33,6 +33,7 @@ const setDateModifier = (
   updateAttribute(dateEl, isDisabled, 'data-vc-date-disabled');
   if (dateBtnEl) updateAttribute(dateBtnEl, isDisabled, 'aria-disabled', 'true');
   if (dateBtnEl) updateAttribute(dateBtnEl, isDisabled, 'tabindex', '-1');
+  if (dateBtnEl) dateBtnEl.disabled = !!isDisabled;
 
   // Check if the date is today
   updateAttribute(dateEl, !self.disableToday && self.context.dateToday === dateStr, 'data-vc-date-today');
@@ -45,10 +46,10 @@ const setDateModifier = (
   const selectedHolidays = self.selectedHolidays?.[0] ? parseDates(self.selectedHolidays) : [];
   updateAttribute(dateEl, selectedHolidays.includes(dateStr), 'data-vc-date-holiday');
 
-  // Check if the date is selected
+  // Check if the date is selected: aria-selected belongs on the gridcell, a button does not support it
   if (self.context.selectedDates?.includes(dateStr)) {
     dateEl.setAttribute('data-vc-date-selected', '');
-    if (dateBtnEl) dateBtnEl.setAttribute('aria-selected', 'true');
+    dateEl.setAttribute('aria-selected', 'true');
     if (self.context.selectedDates.length > 1 && self.selectionDatesMode === 'multiple-ranged') {
       if (self.context.selectedDates[0] === dateStr && self.context.selectedDates[self.context.selectedDates.length - 1] === dateStr) {
         dateEl.setAttribute('data-vc-date-selected', 'first-and-last');
@@ -63,7 +64,7 @@ const setDateModifier = (
     }
   } else if (dateEl.hasAttribute('data-vc-date-selected')) {
     dateEl.removeAttribute('data-vc-date-selected');
-    if (dateBtnEl) dateBtnEl.removeAttribute('aria-selected');
+    dateEl.removeAttribute('aria-selected');
   }
 
   // When using multiple-ranged with range edges only (only includes start/end selected dates)

--- a/package/src/scripts/creators/createDates/updateDateModifiers.ts
+++ b/package/src/scripts/creators/createDates/updateDateModifiers.ts
@@ -1,5 +1,6 @@
 import setDateModifier from '@scripts/creators/createDates/setDateModifier';
 import getDate from '@scripts/utils/getDate';
+import updateRovingTabIndex from '@scripts/utils/rovingTabIndex';
 import type { Calendar, FormatDateString, WeekDayID } from '@src/index';
 
 const updateDateModifiers = (self: Calendar) => {
@@ -10,6 +11,8 @@ const updateDateModifiers = (self: Calendar) => {
     const dayWeekID = getDate(dateStr).getDay() as WeekDayID;
     setDateModifier(self, self.context.selectedYear, dateEl, dateBtnEl, dayWeekID, dateStr, 'current');
   });
+
+  updateRovingTabIndex(self);
 };
 
 export default updateDateModifiers;

--- a/package/src/scripts/creators/createLayouts.ts
+++ b/package/src/scripts/creators/createLayouts.ts
@@ -9,7 +9,8 @@ import type { Calendar } from '@src/index';
 const syncMultiselectable = (self: Calendar) => {
   const isMultiselectable = ['multiple', 'multiple-ranged'].includes(String(self.selectionDatesMode));
   self.context.mainElement.querySelectorAll<HTMLElement>('[data-vc="content"][role="grid"]').forEach((gridEl) => {
-    gridEl.toggleAttribute('aria-multiselectable', isMultiselectable);
+    if (isMultiselectable) gridEl.setAttribute('aria-multiselectable', 'true');
+    else gridEl.removeAttribute('aria-multiselectable');
   });
 };
 

--- a/package/src/scripts/creators/createLayouts.ts
+++ b/package/src/scripts/creators/createLayouts.ts
@@ -6,6 +6,13 @@ import layoutYears from '@scripts/layouts/year';
 import { parseLayout, parseMultipleLayout } from '@scripts/utils/parseComponent';
 import type { Calendar } from '@src/index';
 
+const syncMultiselectable = (self: Calendar) => {
+  const isMultiselectable = ['multiple', 'multiple-ranged'].includes(String(self.selectionDatesMode));
+  self.context.mainElement.querySelectorAll<HTMLElement>('[data-vc="content"][role="grid"]').forEach((gridEl) => {
+    gridEl.toggleAttribute('aria-multiselectable', isMultiselectable);
+  });
+};
+
 const createLayouts = (self: Calendar, target?: HTMLElement) => {
   const templateMap = {
     default: layoutDefault,
@@ -24,12 +31,15 @@ const createLayouts = (self: Calendar, target?: HTMLElement) => {
   self.context.mainElement.dataset.vc = 'calendar';
   self.context.mainElement.dataset.vcType = self.context.currentType;
   self.context.mainElement.toggleAttribute('data-vc-swipe', self.enableSwipe);
-  self.context.mainElement.role = 'application';
-  self.context.mainElement.tabIndex = 0;
+  // Native buttons and a grid need no `application` role, which would only cost screen reader
+  // users their reading commands. In input mode the popup is a dialog the input opens.
+  self.context.mainElement.role = self.inputMode ? 'dialog' : 'group';
+  self.context.mainElement.tabIndex = -1;
   self.context.mainElement.ariaLabel = self.labels.application;
 
   if (self.context.currentType === 'multiple') {
     self.context.mainElement.innerHTML = self.sanitizerHTML(parseMultipleLayout(self, parseLayout(self, self.layouts[self.context.currentType])));
+    syncMultiselectable(self);
     return;
   }
 
@@ -42,10 +52,12 @@ const createLayouts = (self: Calendar, target?: HTMLElement) => {
     if (gridEl) gridEl.dataset.vcGrid = 'hidden';
     if (columnEl) columnEl.dataset.vcColumn = self.context.currentType;
     if (columnEl) columnEl.innerHTML = self.sanitizerHTML(parseLayout(self, self.layouts[self.context.currentType]));
+    syncMultiselectable(self);
     return;
   }
 
   self.context.mainElement.innerHTML = self.sanitizerHTML(parseLayout(self, self.layouts[self.context.currentType]));
+  syncMultiselectable(self);
 };
 
 export default createLayouts;

--- a/package/src/scripts/creators/createMonths.ts
+++ b/package/src/scripts/creators/createMonths.ts
@@ -3,6 +3,7 @@ import setMonthOrYearModifier from '@scripts/creators/setMonthOrYearModifier';
 import visibilityTitle from '@scripts/creators/visibilityTitle';
 import getColumnID from '@scripts/utils/getColumnID';
 import getDate from '@scripts/utils/getDate';
+import updateRovingTabIndex from '@scripts/utils/rovingTabIndex';
 import setContext from '@scripts/utils/setContext';
 import type { Calendar } from '@src/index';
 
@@ -92,7 +93,7 @@ const createMonths = (self: Calendar, target?: HTMLElement) => {
     if (self.onCreateMonthEls) self.onCreateMonthEls(self, monthEl);
   }
 
-  self.context.mainElement.querySelector<HTMLElement>(`[data-vc-months-month]:not([disabled])`)?.focus();
+  updateRovingTabIndex(self);
 };
 
 export default createMonths;

--- a/package/src/scripts/creators/createToInput.ts
+++ b/package/src/scripts/creators/createToInput.ts
@@ -5,6 +5,7 @@ import { show } from '@scripts/methods';
 import reset from '@scripts/methods/reset';
 import getRootNode from '@scripts/utils/getRootNode';
 import setContext from '@scripts/utils/setContext';
+import { hideFromAT } from '@scripts/utils/toggleTabbing';
 import type { Calendar } from '@src/index';
 
 const createToInput = (self: Calendar) => {
@@ -13,6 +14,7 @@ const createToInput = (self: Calendar) => {
   calendar.dataset.vc = 'calendar';
   calendar.dataset.vcInput = '';
   calendar.dataset.vcCalendarHidden = '';
+  hideFromAT(calendar);
 
   // append into the input's own root (a ShadowRoot if the calendar lives inside one, so the
   // popup stays inside the same encapsulated style scope; document.body otherwise, since a

--- a/package/src/scripts/creators/createWeek.ts
+++ b/package/src/scripts/creators/createWeek.ts
@@ -21,17 +21,33 @@ const createWeek = (self: Calendar) => {
   );
   const weekdays = [...weekdaysData.slice(self.firstWeekday), ...weekdaysData.slice(0, self.firstWeekday)];
 
+  // A columnheader is not a role a button may carry, so the clickable variant keeps the header
+  // cell as its own element and nests the button inside it.
+  const isClickable = !!self.onClickWeekDay;
+  const templateWeekDayEl = document.createElement(isClickable ? 'div' : 'b');
+  const templateWeekDayBtnEl = document.createElement('button');
+  templateWeekDayBtnEl.type = 'button';
+  templateWeekDayBtnEl.className = self.styles.weekDayBtn;
+  templateWeekDayBtnEl.dataset.vcWeekDayBtn = '';
+
   self.context.mainElement.querySelectorAll<HTMLElement>('[data-vc="week"]').forEach((weekEl) => {
-    const templateWeekDayEl = !!self.onClickWeekDay ? document.createElement('button') : document.createElement('b');
-    if (!!self.onClickWeekDay) (templateWeekDayEl as HTMLButtonElement).type = 'button';
     weekdays.forEach((weekday) => {
-      const weekDayEl = templateWeekDayEl.cloneNode(true) as HTMLElement;
-      weekDayEl.innerText = weekday.titleShort;
+      const weekDayEl = templateWeekDayEl.cloneNode(false) as HTMLElement;
       weekDayEl.className = self.styles.weekDay;
       weekDayEl.role = 'columnheader';
       weekDayEl.ariaLabel = weekday.titleLong;
       weekDayEl.dataset.vcWeekDay = String(weekday.id);
       if (weekday.isWeekend) weekDayEl.dataset.vcWeekDayOff = '';
+
+      if (isClickable) {
+        const weekDayBtnEl = templateWeekDayBtnEl.cloneNode(false) as HTMLButtonElement;
+        weekDayBtnEl.innerText = weekday.titleShort;
+        weekDayBtnEl.ariaLabel = weekday.titleLong;
+        weekDayEl.appendChild(weekDayBtnEl);
+      } else {
+        weekDayEl.innerText = weekday.titleShort;
+      }
+
       weekEl.appendChild(weekDayEl);
     });
   });

--- a/package/src/scripts/creators/createWeekNumbers.ts
+++ b/package/src/scripts/creators/createWeekNumbers.ts
@@ -16,8 +16,11 @@ const createWeekNumbers = (self: Calendar, firstDayWeek: number, days: number, w
   weekNumbersContentEl.dataset.vcWeekNumbers = 'content';
   weekNumbersEl.appendChild(weekNumbersContentEl);
 
-  const templateWeekNumberEl = document.createElement('button');
-  templateWeekNumberEl.type = 'button';
+  // Only make it a button when there is something to activate, and leave the row/rowheader roles
+  // out of it: the column sits beside the grid, not inside it.
+  const isClickable = !!self.onClickWeekNumber;
+  const templateWeekNumberEl = document.createElement(isClickable ? 'button' : 'b');
+  if (isClickable) (templateWeekNumberEl as HTMLButtonElement).type = 'button';
   templateWeekNumberEl.className = self.styles.weekNumber;
 
   const dateBtnEl = datesEl.querySelectorAll<HTMLButtonElement>('[data-vc-date]');
@@ -30,12 +33,10 @@ const createWeekNumbers = (self: Calendar, firstDayWeek: number, days: number, w
 
     if (!weekNumber) return;
 
-    const weekNumberEl = templateWeekNumberEl.cloneNode(true) as HTMLElement;
+    const weekNumberEl = templateWeekNumberEl.cloneNode(false) as HTMLElement;
     weekNumberEl.innerText = String(weekNumber.week);
     weekNumberEl.dataset.vcWeekNumber = String(weekNumber.week);
     weekNumberEl.dataset.vcWeekYear = String(weekNumber.year);
-    weekNumberEl.role = 'rowheader';
-    weekNumberEl.ariaLabel = `${weekNumber.week}`;
     weekNumbersContentEl.appendChild(weekNumberEl);
   }
 };

--- a/package/src/scripts/creators/createYears.ts
+++ b/package/src/scripts/creators/createYears.ts
@@ -3,6 +3,7 @@ import setMonthOrYearModifier from '@scripts/creators/setMonthOrYearModifier';
 import visibilityArrows from '@scripts/creators/visibilityArrows';
 import visibilityTitle from '@scripts/creators/visibilityTitle';
 import getDate from '@scripts/utils/getDate';
+import updateRovingTabIndex from '@scripts/utils/rovingTabIndex';
 import setContext from '@scripts/utils/setContext';
 import type { Calendar } from '@src/index';
 
@@ -60,7 +61,7 @@ const createYears = (self: Calendar, target?: HTMLElement) => {
     if (self.onCreateYearEls) self.onCreateYearEls(self, yearEl);
   }
 
-  self.context.mainElement.querySelector<HTMLElement>(`[data-vc-years-year]:not([disabled])`)?.focus();
+  updateRovingTabIndex(self);
 };
 
 export default createYears;

--- a/package/src/scripts/handles/handleArrowKeys.ts
+++ b/package/src/scripts/handles/handleArrowKeys.ts
@@ -1,40 +1,60 @@
+import { focusRovingItem } from '@scripts/utils/rovingTabIndex';
 import type { Calendar } from '@src/index';
 
 const handleArrowKeys = (self: Calendar) => {
-  const getOffset = (btn: HTMLButtonElement) => {
-    if (btn.hasAttribute('data-vc-date-btn')) return 7;
-    if (btn.hasAttribute('data-vc-months-month')) return 4;
-    if (btn.hasAttribute('data-vc-years-year')) return 5;
-    return 1;
+  type Grid = { container: string; row: string; item: string };
+  const grids: Grid[] = [
+    { container: '[data-vc="dates"]', row: '[data-vc-dates="row"]', item: '[data-vc-date-btn]' },
+    { container: '[data-vc="months"]', row: '[data-vc-months="row"]', item: '[data-vc-months-month]' },
+    { container: '[data-vc="years"]', row: '[data-vc-years="row"]', item: '[data-vc-years-year]' },
+  ];
+
+  const isEnabled = (button: HTMLButtonElement) => !button.disabled && button.getAttribute('aria-disabled') !== 'true';
+
+  const getVerticalTarget = (gridEl: HTMLElement, grid: Grid, button: HTMLButtonElement, direction: -1 | 1) => {
+    const currentRow = button.closest<HTMLElement>(grid.row);
+    if (!currentRow) return button;
+
+    const rows = Array.from(gridEl.querySelectorAll<HTMLElement>(grid.row));
+    const rowIndex = rows.indexOf(currentRow);
+    const columnIndex = Array.from(currentRow.children).indexOf(button.parentElement as Element);
+    const targetRow = rows[rowIndex + direction];
+    const target = targetRow?.children[columnIndex]?.querySelector<HTMLButtonElement>(grid.item);
+
+    return target && isEnabled(target) ? target : button;
   };
 
   const onKeyDown = (event: KeyboardEvent) => {
-    const target = event.target as HTMLElement;
-    if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key) || target.localName !== 'button') return;
+    const target = (event.target as HTMLElement).closest<HTMLButtonElement>('button');
+    if (!target || !['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) return;
 
-    // the outgoing content lives on in the DOM until the animation ends: inert keeps it out of
-    // the focus order but not out of the query, and indexing the buttons would not survive that
-    const buttons = Array.from(self.context.mainElement.querySelectorAll<HTMLButtonElement>('[data-vc="calendar"] button')).filter(
-      (button) => !button.closest('[data-vc-ghost]'),
-    );
+    const grid = grids.find((item) => target.matches(item.item));
+    const gridEl = grid ? target.closest<HTMLElement>(grid.container) : null;
+    if (!grid || !gridEl || gridEl.closest('[data-vc-ghost]')) return;
+
+    const buttons = Array.from(gridEl.querySelectorAll<HTMLButtonElement>(grid.item)).filter(isEnabled);
     const currentIndex = buttons.indexOf(target as HTMLButtonElement);
     if (currentIndex === -1) return;
 
-    const offset = getOffset(buttons[currentIndex]);
-
-    const direction = {
-      ArrowUp: () => Math.max(0, currentIndex - offset),
-      ArrowDown: () => Math.min(buttons.length - 1, currentIndex + offset),
-      ArrowLeft: () => Math.max(0, currentIndex - 1),
-      ArrowRight: () => Math.min(buttons.length - 1, currentIndex + 1),
+    const nextButton = {
+      ArrowUp: () => getVerticalTarget(gridEl, grid, target, -1),
+      ArrowDown: () => getVerticalTarget(gridEl, grid, target, 1),
+      ArrowLeft: () => buttons[Math.max(0, currentIndex - 1)],
+      ArrowRight: () => buttons[Math.min(buttons.length - 1, currentIndex + 1)],
     }[event.key]!;
 
-    const nextIndex = direction();
-    buttons[nextIndex]?.focus();
+    // Arrow keys move within their grid and must not scroll the page along with them.
+    event.preventDefault();
+    nextButton()?.focus();
   };
 
   self.context.mainElement.addEventListener('keydown', onKeyDown);
-  return () => self.context.mainElement.removeEventListener('keydown', onKeyDown);
+  self.context.mainElement.addEventListener('focusin', focusRovingItem);
+
+  return () => {
+    self.context.mainElement.removeEventListener('keydown', onKeyDown);
+    self.context.mainElement.removeEventListener('focusin', focusRovingItem);
+  };
 };
 
 export default handleArrowKeys;

--- a/package/src/scripts/handles/handleClick/handleClickMonthOrYear.ts
+++ b/package/src/scripts/handles/handleClick/handleClickMonthOrYear.ts
@@ -109,6 +109,11 @@ const handleItemClick = (self: Calendar, event: MouseEvent, type: (typeof typeCl
   }
 };
 
+// The picker is opened by a click, so the focus follows it onto its own tab stop. It must not
+// move on any other render: navigating the year list would otherwise pull the focus off the arrow.
+const focusPicker = (self: Calendar, type: (typeof typeClick)[number], columnEl: HTMLElement | null) =>
+  (columnEl ?? self.context.mainElement).querySelector<HTMLElement>(`[data-vc-${type}s-${type}][tabindex="0"]`)?.focus();
+
 const handleClickType = (self: Calendar, event: MouseEvent, type: (typeof typeClick)[number]) => {
   const target = event.target as HTMLElement;
 
@@ -119,7 +124,11 @@ const handleClickType = (self: Calendar, event: MouseEvent, type: (typeof typeCl
     month: () => changeType(self, columnIndex, () => createMonths(self, target)),
   };
   if (headerEl && self.onClickTitle) self.onClickTitle(self, event);
-  if (headerEl && self.context.currentType !== type) return createByType[type]();
+  if (headerEl && self.context.currentType !== type) {
+    const columnEl = target.closest<HTMLElement>(COLUMN);
+    createByType[type]();
+    return focusPicker(self, type, columnEl);
+  }
 
   const itemEl = target.closest<HTMLButtonElement>(`[data-vc-${type}s-${type}]`);
   if (itemEl) return handleItemClick(self, event, type, itemEl);

--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -8,6 +8,15 @@ import type { Calendar } from '@src/index';
 
 const handleInput = (self: Calendar) => {
   setContext(self, 'inputElement', self.context.mainElement as HTMLInputElement);
+  const inputElement = self.context.inputElement as HTMLInputElement;
+  // Announce that the field opens a picker. Only a form control has a role that carries it:
+  // inputMode also accepts a plain element, which has none.
+  if (['input', 'button', 'textarea'].includes(inputElement.localName)) {
+    inputElement.setAttribute('aria-haspopup', 'dialog');
+    if (inputElement.localName === 'button' || inputElement.getAttribute('role') === 'combobox') {
+      inputElement.setAttribute('aria-expanded', 'false');
+    }
+  }
 
   const handleOpenCalendar = () => {
     if (self.context.inputModeInit) {

--- a/package/src/scripts/handles/handleNavigate.ts
+++ b/package/src/scripts/handles/handleNavigate.ts
@@ -5,6 +5,7 @@ import visibilityTitle from '@scripts/creators/visibilityTitle';
 import animate from '@scripts/utils/animate';
 import getDate from '@scripts/utils/getDate';
 import getDateString from '@scripts/utils/getDateString';
+import getRootNode from '@scripts/utils/getRootNode';
 import setContext from '@scripts/utils/setContext';
 import setWeekDate from '@scripts/utils/setWeekDate';
 import type { Calendar, Range } from '@src/index';
@@ -52,14 +53,32 @@ export const getNavigator = (self: Calendar): Navigator | null => {
   )[self.context.currentType];
 };
 
+// The year list re-renders the whole layout, arrows included, so whatever was focused can be gone
+// by the time it settles. Hand the focus back rather than let it drop to the document.
+const keepFocusInside = (self: Calendar, route: Route, hadFocus: boolean) => {
+  const { mainElement } = self.context;
+  if (!hadFocus || mainElement.contains(getRootNode(mainElement).activeElement)) return;
+
+  const arrowEl = mainElement.querySelector<HTMLElement>(`[data-vc-arrow="${route}"]`);
+  if (arrowEl && arrowEl.style.visibility !== 'hidden') return arrowEl.focus();
+
+  Array.from(mainElement.querySelectorAll<HTMLElement>('[tabindex="0"]'))
+    .find((el) => !el.closest('[data-vc-ghost]'))
+    ?.focus();
+};
+
 const handleNavigate = (self: Calendar, route: Route, target?: HTMLElement) => {
   const navigator = getNavigator(self);
   if (!navigator) return;
+
+  const { mainElement } = self.context;
+  const hadFocus = mainElement.contains(getRootNode(mainElement).activeElement);
 
   navigator.shift(route);
   visibilityTitle(self);
   visibilityArrows(self);
   animate(self, navigator.selector, route, () => navigator.render(target));
+  keepFocusInside(self, route, hadFocus);
 };
 
 export default handleNavigate;

--- a/package/src/scripts/handles/handleTime/handleTime.ts
+++ b/package/src/scripts/handles/handleTime/handleTime.ts
@@ -8,8 +8,8 @@ const handleMouseOver = (inputEl: HTMLInputElement) => inputEl.setAttribute('dat
 const handleMouseOut = (inputEl: HTMLInputElement) => inputEl.removeAttribute('data-vc-input-focus');
 
 const handleTime = (self: Calendar, timeEl: HTMLElement) => {
-  const rangeHourEl = timeEl.querySelector<HTMLInputElement>('[data-vc-time-range="hour"] input[name="hour"]');
-  const rangeMinuteEl = timeEl.querySelector<HTMLInputElement>('[data-vc-time-range="minute"] input[name="minute"]');
+  const rangeHourEl = timeEl.querySelector<HTMLInputElement>('[data-vc-time-range="hour"] input');
+  const rangeMinuteEl = timeEl.querySelector<HTMLInputElement>('[data-vc-time-range="minute"] input');
   const inputHourEl = timeEl.querySelector<HTMLInputElement>('[data-vc-time-input="hour"] input[name="hour"]');
   const inputMinuteEl = timeEl.querySelector<HTMLInputElement>('[data-vc-time-input="minute"] input[name="minute"]');
   const keepingTimeEl = timeEl.querySelector<HTMLButtonElement>('[data-vc-time="keeping"]');

--- a/package/src/scripts/layouts/default.ts
+++ b/package/src/scripts/layouts/default.ts
@@ -1,9 +1,9 @@
 import type { Calendar } from '@src/index';
 
 const layoutDefault = (self: Calendar) => `
-  <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+  <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
     <#ArrowPrev [month] />
-    <div class="${self.styles.headerContent}" data-vc-header="content">
+    <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
       <#Month />
       <#Year />
     </div>

--- a/package/src/scripts/layouts/month.ts
+++ b/package/src/scripts/layouts/month.ts
@@ -1,8 +1,8 @@
 import type { Calendar } from '@src/index';
 
 const layoutMonths = (self: Calendar) => `
-  <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
-    <div class="${self.styles.headerContent}" data-vc-header="content">
+  <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
+    <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
       <#Month />
       <#Year />
     </div>

--- a/package/src/scripts/layouts/multiple.ts
+++ b/package/src/scripts/layouts/multiple.ts
@@ -1,22 +1,22 @@
 import type { Calendar } from '@src/index';
 
 const layoutMultiple = (self: Calendar) => `
-  <div class="${self.styles.controls}" data-vc="controls" role="toolbar" aria-label="${self.labels.navigation}">
+  <div class="${self.styles.controls}" data-vc="controls" role="group" aria-label="${self.labels.navigation}">
     <#ArrowPrev [month] />
     <#ArrowNext [month] />
   </div>
   <div class="${self.styles.grid}" data-vc="grid">
     <#Multiple>
-      <div class="${self.styles.column}" data-vc="column" role="region">
+      <div class="${self.styles.column}" data-vc="column" role="group">
         <div class="${self.styles.header}" data-vc="header">
-          <div class="${self.styles.headerContent}" data-vc-header="content">
+          <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
             <#Month />
             <#Year />
           </div>
         </div>
         <div class="${self.styles.wrapper}" data-vc="wrapper">
           <#WeekNumbers />
-          <div class="${self.styles.content}" data-vc="content" role="grid" aria-multiselectable="true">
+          <div class="${self.styles.content}" data-vc="content" role="grid">
             <#Week />
             <#Dates />
           </div>

--- a/package/src/scripts/layouts/week.ts
+++ b/package/src/scripts/layouts/week.ts
@@ -1,9 +1,9 @@
 import type { Calendar } from '@src/index';
 
 const layoutWeek = (self: Calendar) => `
-  <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+  <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
     <#ArrowPrev [week] />
-    <div class="${self.styles.headerContent}" data-vc-header="content">
+    <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
       <#Month />
       <#Year />
     </div>

--- a/package/src/scripts/layouts/year.ts
+++ b/package/src/scripts/layouts/year.ts
@@ -1,9 +1,9 @@
 import type { Calendar } from '@src/index';
 
 const layoutYears = (self: Calendar) => `
-  <div class="${self.styles.header}" data-vc="header" role="toolbar" aria-label="${self.labels.navigation}">
+  <div class="${self.styles.header}" data-vc="header" role="group" aria-label="${self.labels.navigation}">
     <#ArrowPrev [year] />
-    <div class="${self.styles.headerContent}" data-vc-header="content">
+    <div class="${self.styles.headerContent}" data-vc-header="content" aria-live="polite" aria-atomic="true">
       <#Month />
       <#Year />
     </div>

--- a/package/src/scripts/methods/hide.ts
+++ b/package/src/scripts/methods/hide.ts
@@ -1,22 +1,26 @@
 import getRootNode from '@scripts/utils/getRootNode';
 import setContext from '@scripts/utils/setContext';
 import { setSkipOpenOnFocus } from '@scripts/utils/skipOpenOnFocus';
-import { disableTabbing } from '@scripts/utils/toggleTabbing';
+import { hideFromAT } from '@scripts/utils/toggleTabbing';
 import type { Calendar } from '@src/index';
 
 const hide = (self: Calendar) => {
   if (!self.context.isShowInInputMode || !self.context.currentType) return;
 
+  // `inert` blurs whatever it covers, so where the focus stands has to be read before it is set
+  const hasFocusInside = self.context.mainElement.contains(getRootNode(self.context.mainElement).activeElement);
+
   self.context.mainElement.dataset.vcCalendarHidden = '';
   setContext(self, 'isShowInInputMode', false);
-  if (self.inputMode) disableTabbing(self.context.mainElement);
+  if (self.inputMode) hideFromAT(self.context.mainElement);
+  if (self.context.inputElement?.hasAttribute('aria-expanded')) self.context.inputElement.setAttribute('aria-expanded', 'false');
 
   if (self.context.cleanupHandlers[0]) {
     self.context.cleanupHandlers.forEach((cleanup) => cleanup());
     setContext(self, 'cleanupHandlers', []);
   }
 
-  if (self.inputMode && self.context.inputElement && self.context.mainElement.contains(getRootNode(self.context.mainElement).activeElement)) {
+  if (self.inputMode && self.context.inputElement && hasFocusInside) {
     const shouldHandleFocus = typeof self.openOnFocus === 'function' || self.openOnFocus === true;
     if (shouldHandleFocus) setSkipOpenOnFocus(self);
     self.context.inputElement.focus();

--- a/package/src/scripts/methods/show.ts
+++ b/package/src/scripts/methods/show.ts
@@ -1,7 +1,7 @@
 import hide from '@scripts/methods/hide';
 import setPosition from '@scripts/utils/positions/setPosition';
 import setContext from '@scripts/utils/setContext';
-import { restoreTabbing } from '@scripts/utils/toggleTabbing';
+import { showToAT } from '@scripts/utils/toggleTabbing';
 import type { Calendar } from '@src/index';
 
 const show = (self: Calendar) => {
@@ -14,9 +14,10 @@ const show = (self: Calendar) => {
 
   setContext(self, 'cleanupHandlers', []);
   setContext(self, 'isShowInInputMode', true);
-  if (self.inputMode) restoreTabbing(self.context.mainElement);
+  if (self.inputMode) showToAT(self.context.mainElement);
   setPosition(self.context.inputElement, self.context.mainElement, self.positionToInput);
   self.context.mainElement.removeAttribute('data-vc-calendar-hidden');
+  if (self.context.inputElement?.hasAttribute('aria-expanded')) self.context.inputElement.setAttribute('aria-expanded', 'true');
 
   const handleResize = () => {
     setPosition(self.context.inputElement, self.context.mainElement, self.positionToInput);

--- a/package/src/scripts/utils/rovingTabIndex.ts
+++ b/package/src/scripts/utils/rovingTabIndex.ts
@@ -1,0 +1,48 @@
+import type { Calendar } from '@src/index';
+
+type Group = { container: string; item: string; active: string[] };
+
+// A grid is a single tab stop: the arrow keys reach the rest of its cells.
+const groups: Group[] = [
+  {
+    container: '[data-vc="dates"]',
+    item: '[data-vc-date-btn]',
+    active: ['[data-vc-date-selected] [data-vc-date-btn]', '[data-vc-date-today] [data-vc-date-btn]'],
+  },
+  { container: '[data-vc="months"]', item: '[data-vc-months-month]', active: ['[data-vc-months-month-selected]'] },
+  { container: '[data-vc="years"]', item: '[data-vc-years-year]', active: ['[data-vc-years-year-selected]'] },
+];
+
+const isEnabled = (el: HTMLElement) => !el.hasAttribute('disabled') && el.getAttribute('aria-disabled') !== 'true';
+
+const getActiveItem = (containerEl: HTMLElement, group: Group, items: HTMLElement[]) => {
+  const preferred = group.active.map((selector) => containerEl.querySelector<HTMLElement>(selector)).find((el): el is HTMLElement => !!el && isEnabled(el));
+  return preferred ?? items.find(isEnabled) ?? items[0];
+};
+
+const setRovingItem = (containerEl: HTMLElement, group: Group, activeEl: HTMLElement | null) => {
+  const items = Array.from(containerEl.querySelectorAll<HTMLElement>(group.item));
+  if (!items[0]) return;
+  const active = activeEl && isEnabled(activeEl) ? activeEl : getActiveItem(containerEl, group, items);
+  items.forEach((item) => {
+    item.tabIndex = item === active ? 0 : -1;
+  });
+};
+
+export const focusRovingItem = (event: FocusEvent) => {
+  const target = event.target as HTMLElement;
+  const group = groups.find((item) => target.matches?.(item.item));
+  const containerEl = group ? target.closest<HTMLElement>(group.container) : null;
+  if (group && containerEl) setRovingItem(containerEl, group, target);
+};
+
+const updateRovingTabIndex = (self: Calendar) => {
+  groups.forEach((group) => {
+    self.context.mainElement.querySelectorAll<HTMLElement>(group.container).forEach((containerEl) => {
+      if (containerEl.closest('[data-vc-ghost]')) return;
+      setRovingItem(containerEl, group, null);
+    });
+  });
+};
+
+export default updateRovingTabIndex;

--- a/package/src/scripts/utils/toggleTabbing.ts
+++ b/package/src/scripts/utils/toggleTabbing.ts
@@ -40,3 +40,17 @@ export const restoreTabbing = (root: HTMLElement) => {
   restorePrevTabIndex(root);
   root.querySelectorAll<HTMLElement>(`[${PREV_TABINDEX_ATTR}]`).forEach(restorePrevTabIndex);
 };
+
+// `inert` takes the closed popup out of the focus order and the accessibility tree in one go;
+// the tabindex bookkeeping above stays as the fallback for browsers that do not support it.
+export const hideFromAT = (root: HTMLElement) => {
+  root.setAttribute('inert', '');
+  root.ariaHidden = 'true';
+  disableTabbing(root);
+};
+
+export const showToAT = (root: HTMLElement) => {
+  root.removeAttribute('inert');
+  root.removeAttribute('aria-hidden');
+  restoreTabbing(root);
+};

--- a/package/src/styles.ts
+++ b/package/src/styles.ts
@@ -21,6 +21,7 @@ const styles = {
   yearsYear: 'vc-years__year',
   week: 'vc-week',
   weekDay: 'vc-week__day',
+  weekDayBtn: 'vc-week__day-btn',
   weekNumbers: 'vc-week-numbers',
   weekNumbersTitle: 'vc-week-numbers__title',
   weekNumbersContent: 'vc-week-numbers__content',

--- a/package/src/styles/layout.css
+++ b/package/src/styles/layout.css
@@ -114,11 +114,11 @@
 }
 
 [data-vc-week-numbers='title'] {
-  @apply text-xs font-bold flex items-center justify-center mb-2;
+  @apply text-xs font-bold flex items-center min-h-6 justify-center mb-1.5;
 }
 
 [data-vc-week-numbers='content'] {
-  @apply grid grid-flow-row items-center justify-items-center gap-y-1;
+  @apply grid grid-flow-row items-center justify-items-center gap-y-1 py-0.5;
 }
 
 [data-vc-week-number] {
@@ -126,15 +126,15 @@
 }
 
 [data-vc='week'] {
-  @apply grid grid-cols-[repeat(7,_1fr)] justify-items-center mb-2;
+  @apply grid grid-cols-[repeat(7,_1fr)] justify-items-center mb-1.5;
 }
 
 [data-vc-week-day] {
   @apply text-xs font-bold w-full min-w-[1.875rem] flex items-center justify-center bg-transparent border-none p-0 m-0;
 }
 
-button[data-vc-week-day] {
-  @apply cursor-pointer;
+[data-vc-week-day-btn] {
+  @apply text-xs font-bold w-full h-full min-h-6 flex items-center justify-center cursor-pointer bg-transparent border-none p-0 m-0;
 }
 
 [data-vc='collapse'] {
@@ -334,7 +334,7 @@ button[data-vc-week-day] {
 }
 
 [data-vc-time-range] input {
-  @apply w-full relative appearance-none h-5 cursor-pointer m-0 outline-0;
+  @apply w-full relative appearance-none h-6 cursor-pointer m-0 outline-0;
 }
 
 [data-vc-time-range] input::-webkit-slider-thumb {

--- a/package/src/styles/layout.css
+++ b/package/src/styles/layout.css
@@ -130,7 +130,7 @@
 }
 
 [data-vc-week-day] {
-  @apply text-xs font-bold w-full min-w-[1.875rem] flex items-center justify-center bg-transparent border-none p-0 m-0;
+  @apply text-xs font-bold w-full min-h-6 min-w-[1.875rem] flex items-center justify-center bg-transparent border-none p-0 m-0;
 }
 
 [data-vc-week-day-btn] {


### PR DESCRIPTION
Fixes #408

## Problem

The calendar had several accessibility issues affecting ARIA semantics, keyboard navigation and focus handling. Demo pages also lacked consistent landmark navigation and contained HTML validation errors.

## Fix

- Corrected grid, row and gridcell semantics across date, month and year layouts.
- Moved ARIA state to elements whose roles support it.
- Added roving tabindex and predictable arrow-key navigation within the active grid.
- Made disabled dates native disabled controls and excluded them from keyboard navigation.
- Improved input-mode popup semantics, focus restoration and expanded state handling.
- Synced `aria-multiselectable` after every render and options update.
- Added accessible time controls and improved labels for interactive calendar elements.
- Added skip links and main landmarks to all demo pages.
- Fixed demo HTML validation: normalized document structure, void elements, titles and label/input association.

## Testing

- `npm run test:cypress:a11y` — 22 passing accessibility checks.
- `npx html-validate demo/index.html 'demo/pages/*/index.html'` — no errors.
- `npm run build` — successful.

## Notes

Automated axe checks cover the applicable ARIA and WCAG 2.1 rules for calendar markup. Color contrast remains outside this PR’s scope.