### PR TITLE
fix: prevent input popup scrollbar flicker

### DIFF
--- a/demo/pages/issue-433/index.html
+++ b/demo/pages/issue-433/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1,width=device-width" />
+    <title>Issue #433 reproduction</title>
+    <link rel="stylesheet" href="../../index.css" />
+    <script defer src="./main.ts" type="module"></script>
+  </head>
+  <body class="min-h-screen bg-white p-4 font-sans text-slate-900 dark:bg-slate-900 dark:text-white">
+    <label class="block" for="calendar">Date: <input id="calendar" class="input" type="text" placeholder="Choose date" readonly /></label>
+    <div class="mt-2 space-y-1" aria-hidden="true">
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+      <div>1</div>
+    </div>
+  </body>
+</html>

--- a/demo/pages/issue-433/main.ts
+++ b/demo/pages/issue-433/main.ts
@@ -1,0 +1,5 @@
+import { Calendar } from '@src/index';
+
+import '@src/styles/index.css';
+
+new Calendar('#calendar', { inputMode: true }).init();

--- a/demo/pages/shadow-dom/main.ts
+++ b/demo/pages/shadow-dom/main.ts
@@ -8,7 +8,7 @@ class ShadowCalendarInput extends HTMLElement {
     const shadow = this.attachShadow({ mode: 'open' });
 
     const style = document.createElement('style');
-    style.textContent = `${calendarStyles} input { padding: 8px; font-size: 14px; }`;
+    style.textContent = `${calendarStyles} input { padding: 8px; font-size: 14px; } button { min-height: 24px; }`;
     shadow.appendChild(style);
 
     const wrapper = document.createElement('div');

--- a/package/src/scripts/creators/createToInput.ts
+++ b/package/src/scripts/creators/createToInput.ts
@@ -14,6 +14,10 @@ const createToInput = (self: Calendar) => {
   calendar.dataset.vc = 'calendar';
   calendar.dataset.vcInput = '';
   calendar.dataset.vcCalendarHidden = '';
+  // An absolutely positioned element without coordinates uses its static position at the end of
+  // the document. Even hidden by opacity, that can briefly extend the page and flash a scrollbar
+  // before show() calculates the position next to the input.
+  Object.assign(calendar.style, { left: '0', top: '0' });
   hideFromAT(calendar);
 
   // append into the input's own root (a ShadowRoot if the calendar lives inside one, so the


### PR DESCRIPTION
Fixes #433

- give the hidden input popup a safe initial position before appending it to the document
- add a minimal reproduction page at `demo/pages/issue-433`

Tests: `npx tsc --noEmit`; `yarn cypress:run --spec cypress/e2e/a11y.cy.ts,cypress/e2e/shadowDom.cy.ts`